### PR TITLE
chore(github): add issue forms + PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Something broken in the C++ core, HTTP server, web app, or tooling
+title: "[bug] "
+labels: ["type/fix", "status/needs-triage"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - core-matrix
+        - core-neuralnet
+        - server
+        - web
+        - tooling
+        - ci
+        - docs
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      placeholder: "Describe observed vs expected"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal repro
+      placeholder: "Exact commands + inputs"
+  - type: input
+    id: version
+    attributes:
+      label: Commit or tag
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      placeholder: "OS, compiler, CPU features"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/yadava5/fast-mnist-nn/discussions/categories/q-a
+    about: Ask a question in Discussions.
+  - name: Security vulnerability
+    url: https://github.com/yadava5/fast-mnist-nn/security/advisories/new
+    about: Report privately via GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Propose a new capability
+title: "[feat] "
+labels: ["type/feat", "status/needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria

--- a/.github/ISSUE_TEMPLATE/performance_regression.yml
+++ b/.github/ISSUE_TEMPLATE/performance_regression.yml
@@ -1,0 +1,29 @@
+name: Performance regression
+description: A benchmark got slower or a latency target was missed
+title: "[perf] "
+labels: ["type/perf", "priority/p1"]
+body:
+  - type: dropdown
+    id: kernel
+    attributes:
+      label: Affected kernel
+      options:
+        - matrix.dot
+        - matrix.transpose
+        - matrix.axpy
+        - neuralnet.learn
+        - neuralnet.classify
+        - server.predict_p99
+    validations:
+      required: true
+  - type: textarea
+    id: numbers
+    attributes:
+      label: Before -> After numbers with methodology
+      placeholder: "Include hardware, sample size, median + MAD or p50/p99, and the exact command(s) used."
+    validations:
+      required: true
+  - type: textarea
+    id: bisect
+    attributes:
+      label: Bisect result or suspected commit range

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,17 @@
+name: RFC / Architecture Decision
+description: Propose a design change worth a written record (becomes an ADR)
+title: "[rfc] "
+labels: ["type/rfc"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+  - type: textarea
+    id: decision
+    attributes:
+      label: Proposed decision
+  - type: textarea
+    id: consequences
+    attributes:
+      label: Consequences (good and bad)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+<!-- One or two sentences. What changes? -->
+
+Closes #<issue>
+
+## Why
+<!-- The underlying problem or goal. Link to ADR/RFC if applicable. -->
+
+## Changes
+<!-- Bulleted list of concrete changes per file or per module. -->
+
+## Test plan
+<!-- Exact commands run; results observed. Prefer reproducible repros. -->
+- [ ] `ctest --test-dir build` passes
+- [ ] `npm run build` + `npm run lint` pass
+- [ ] New tests added for new behavior
+- [ ] Benchmark numbers attached if a hot path changed
+
+## Perf impact
+<!-- If a kernel changed, paste before/after from `scripts/bench.sh` with median + MAD + CI. -->
+
+## Screenshots / recordings
+<!-- If UI changed. -->
+
+## Breaking changes
+<!-- API, CLI, file format, HTTP contract. "None" if none. -->
+
+## Rollback plan
+<!-- How to revert. -->
+
+## Checklist
+- [ ] Conventional Commit title
+- [ ] CI green (CodeQL, sanitizers, perf, coverage)
+- [ ] CodeRabbit approval (optional for now)
+- [ ] Docs updated (README, ADR, or CHANGELOG)
+- [ ] No secrets, PII, or large binaries added


### PR DESCRIPTION
Closes #2

## Summary
Add four YAML issue forms (bug, feature, performance regression, RFC), an issue-template `config.yml` that disables blank issues and routes questions + security reports, and a `pull_request_template.md` covering the sections we care about (test plan, perf impact, breaking changes, rollback).

## Why
Reporters currently submit free-form issues without area routing, repro steps, or commit anchors, and PRs land with inconsistent descriptions. Structured forms demand the minimum context needed to triage, and the PR template makes the review bar explicit.

## Changes
- `.github/ISSUE_TEMPLATE/bug_report.yml` — area dropdown, what-happened (required), repro, version, environment
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem (required), proposal, alternatives, acceptance criteria
- `.github/ISSUE_TEMPLATE/performance_regression.yml` — kernel dropdown (required), before/after numbers with methodology (required), bisect range; auto-labels `priority/p1`
- `.github/ISSUE_TEMPLATE/rfc.yml` — context, decision, consequences (seed for an ADR)
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`, contact links to Discussions Q&A and Security Advisories
- `.github/pull_request_template.md` — Summary / Why / Changes / Test plan / Perf impact / Screenshots / Breaking changes / Rollback plan / Checklist

## Test plan
- [x] `yq e '.' <file>` parses every YAML file cleanly
- [ ] Open a test issue via each form after merge and verify correct labels + title prefix
- [ ] Open a draft PR after merge and verify the template auto-loads

## Breaking changes
None

## Rollback plan
Revert this PR; removing `.github/ISSUE_TEMPLATE/` and `pull_request_template.md` restores the default GitHub "blank issue / blank PR" flow.