### PR TITLE
feat(web): install motion v12 + spring/ease tokens

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "web",
-  "version": "0.0.0",
+  "name": "fast-mnist-web",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "web",
-      "version": "0.0.0",
+      "name": "fast-mnist-web",
+      "version": "1.0.0",
       "dependencies": {
         "axios": "^1.13.2",
+        "motion": "^12.38.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1988,6 +1989,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2658,6 +2686,47 @@
         "node": "*"
       }
     },
+    "node_modules/motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
+      "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.38.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3046,9 +3115,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.13.2",
+    "motion": "^12.38.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/web/src/lib/ease.ts
+++ b/web/src/lib/ease.ts
@@ -1,0 +1,4 @@
+export const ease = {
+  enter: [0.16, 1, 0.3, 1] as const,
+  exit: [0.7, 0, 0.84, 0] as const,
+};

--- a/web/src/lib/springs.ts
+++ b/web/src/lib/springs.ts
@@ -1,0 +1,7 @@
+import type { Transition } from 'motion/react';
+
+export const springs = {
+  gentle: { type: 'spring', stiffness: 170, damping: 26, mass: 1 } as Transition,
+  quick: { type: 'spring', stiffness: 300, damping: 30, mass: 0.8 } as Transition,
+  bouncy: { type: 'spring', stiffness: 500, damping: 15, mass: 1 } as Transition,
+};


### PR DESCRIPTION
Closes #11

## Summary
Install motion@^12.38.0 and add `web/src/lib/springs.ts` + `web/src/lib/ease.ts` containing the shared spring/ease transition vocabulary used by the rest of the frontend redesign.

## Why
Link to the issue #11. Motion v12 is the canonical animation engine for the redesign; centralized tokens prevent drift across components.

## Changes
- `web/package.json` + `web/package-lock.json`: add motion@^12.38.0
- `web/src/lib/springs.ts`: `gentle`, `quick`, `bouncy` Transition presets typed via `motion/react`
- `web/src/lib/ease.ts`: `enter`, `exit` cubic-bezier tuples (`as const`)

## Test plan
- [x] `cd web && npm install` succeeds
- [x] `cd web && npm run build` passes (237.65 kB main, 8.17 kB css)
- [x] `cd web && npm run lint` passes
- [ ] Visual smoke test: `npm run dev` -> page still renders (no import sites yet so visual output is unchanged)

## Breaking changes
None.

## Rollback plan
Revert the PR.