### PR TITLE
chore(automation): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 10
+    labels: ["type/chore", "area/hygiene"]
+    groups:
+      minor-and-patch:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels: ["type/chore", "area/hygiene"]


### PR DESCRIPTION
Closes #3

## Summary
Add `.github/dependabot.yml` covering weekly npm updates for `/web` (grouped minor+patch for dev dependencies) and weekly `github-actions` updates at repo root. Both are labeled `type/chore` + `area/hygiene`.

## Why
No automated dependency surveillance today — security advisories and version drift only surface when someone notices a breaking upgrade. Grouping dev-deps minor+patch keeps the queue manageable while still surfacing majors individually.

## Changes
- `.github/dependabot.yml` — schema v2, two ecosystems (npm @ `/web`, github-actions @ `/`)

## Test plan
- [x] `yq e '.' .github/dependabot.yml` parses cleanly
- [ ] After merge, Dependabot tab in repo Insights shows both ecosystems detected
- [ ] First Monday after merge produces a grouped PR labeled `type/chore` + `area/hygiene`

## Breaking changes
None

## Rollback plan
Revert this PR; Dependabot will stop opening new PRs.