### PR TITLE
chore(security): add CodeQL workflow (cpp + js/ts)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+  packages: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [cpp, javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild (C/C++)
+        if: matrix.language == 'cpp'
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #4

## Summary
Add `.github/workflows/codeql.yml` running the GitHub CodeQL analysis on a matrix of `cpp` and `javascript-typescript`. Triggers on push/PR to `main` and weekly at Mon 03:00 UTC.

## Why
No static-analysis security layer today — a use-after-free in the matrix kernels or a DOM-XSS in the React app could land silently. The weekly cron also catches vulns introduced by new CodeQL queries even when the code hasn't changed.

## Changes
- `.github/workflows/codeql.yml` — matrix `[cpp, javascript-typescript]`, `init@v3` / `autobuild@v3` (cpp-only) / `analyze@v3` with per-language `category`, proper `security-events: write` permission

## Test plan
- [x] `yq e '.' .github/workflows/codeql.yml` parses cleanly
- [ ] After merge, workflow appears under Actions tab
- [ ] First scheduled run (next Monday 03:00 UTC) uploads SARIF to Security -> Code scanning
- [ ] A PR against `main` that touches `src/**` triggers the workflow

## Breaking changes
None

## Rollback plan
Revert this PR; workflow stops running.