### PR TITLE
chore(security): add gitleaks secret-scanning workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,26 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #5

## Summary
Add `.github/workflows/gitleaks.yml` that runs `gitleaks/gitleaks-action@v2` on every PR, every push to `main`, and on a weekly cron (Mon 04:00 UTC). Fails the job on leak detected (default behavior).

## Why
No pre-merge secret-scan today — an API key committed to the history persists forever even after a later "remove" commit. The weekly cron also catches secrets flagged by newly-added gitleaks rules against existing history.

## Changes
- `.github/workflows/gitleaks.yml` — `pull_request` / `push` to main / weekly cron, `contents: read` permission, `fetch-depth: 0` so the full history is scanned, action receives `GITHUB_TOKEN` for PR comments

## Test plan
- [x] `yq e '.' .github/workflows/gitleaks.yml` parses cleanly
- [ ] After merge, opening a PR triggers the `gitleaks / scan` check
- [ ] A deliberate test secret in a branch fails the check (verified out-of-band, not in this PR)

## Breaking changes
None

## Rollback plan
Revert this PR; workflow stops running.