### PR TITLE
chore(automation): add commitlint CI check

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,23 @@
+name: commitlint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-commits:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint commits with commitlint
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: web/commitlint.config.js


### PR DESCRIPTION
Closes #10

## Summary
Add `.github/workflows/commitlint.yml` that runs `wagoid/commitlint-github-action@v6` against `web/commitlint.config.js` on every pull request.

## Why
Conventional Commits are the source of truth for release-please and CHANGELOG automation downstream. Nothing enforces the format today, so a stray commit silently breaks release tooling. Gating at PR time keeps `main`'s linear history clean without forcing every local commit to be perfect.

## Dependency note
This CI check reads `web/commitlint.config.js`, which is added by agent γ in issue #6. Until #6 lands, this workflow will fail on missing config — **expected and OK**. It goes green automatically once #6 merges.

## Changes
- `.github/workflows/commitlint.yml` — `pull_request` trigger, `contents: read` + `pull-requests: read`, `fetch-depth: 0`, `configFile: web/commitlint.config.js`

## Test plan
- [x] `yq e '.' .github/workflows/commitlint.yml` parses cleanly
- [ ] After merge + after #6 lands, opening a PR with a Conventional Commit title passes
- [ ] A PR with a non-conforming commit subject fails the check

## Breaking changes
None

## Rollback plan
Revert this PR; workflow stops running.