### PR TITLE
feat(web): theme module + View Transitions crossfade

### DIFF
--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,27 +1,21 @@
 import { useState, useEffect, useCallback } from 'react';
+import { applyTheme, readInitialTheme, type Theme } from '../lib/theme';
 
-export type Theme = 'dark' | 'light';
+export type { Theme };
 
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const stored = localStorage.getItem('theme');
-    if (stored === 'light' || stored === 'dark') {
-      return stored;
-    }
-    // Check system preference
-    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      return 'light';
-    }
-    return 'dark';
-  });
+  const [theme, setThemeState] = useState<Theme>(() => readInitialTheme());
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('theme', theme);
+    applyTheme(theme);
   }, [theme]);
 
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+  }, []);
+
   const toggleTheme = useCallback(() => {
-    setTheme(prev => prev === 'dark' ? 'light' : 'dark');
+    setThemeState((prev) => (prev === 'dark' ? 'light' : 'dark'));
   }, []);
 
   return { theme, setTheme, toggleTheme };

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -94,3 +94,10 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+@media (prefers-reduced-motion: no-preference) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 300ms;
+  }
+}

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,35 @@
+export type Theme = 'dark' | 'light';
+
+export const THEME_KEY = 'theme';
+
+export function applyTheme(next: Theme) {
+  const doc = document.documentElement;
+  const run = () => {
+    doc.dataset.theme = next;
+    try {
+      localStorage.setItem(THEME_KEY, next);
+    } catch {
+      // localStorage may be unavailable (e.g. privacy mode); theme still
+      // applies visually, just not persisted.
+    }
+  };
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (!reduced && 'startViewTransition' in document) {
+    (document as unknown as { startViewTransition: (cb: () => void) => void })
+      .startViewTransition(run);
+  } else {
+    run();
+  }
+}
+
+export function readInitialTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch {
+    // ignored — fall through to system preference
+  }
+  return window.matchMedia('(prefers-color-scheme: light)').matches
+    ? 'light'
+    : 'dark';
+}


### PR DESCRIPTION
Closes #15

## Summary
Extract theme init/apply into `web/src/lib/theme.ts`, rewrite `useTheme` to delegate to those helpers (keeping the `{ theme, setTheme, toggleTheme }` API intact), and add a 300ms View Transitions root-crossfade scoped behind `prefers-reduced-motion: no-preference`.

## Why
Link to issue #15. Centralizing theme logic means the crossfade + reduced-motion fallback lives in one place instead of leaking into every consumer.

## Changes
- `web/src/lib/theme.ts`: `Theme`, `THEME_KEY`, `applyTheme()` (View Transitions + reduced-motion guard), `readInitialTheme()`
- `web/src/hooks/useTheme.ts`: thin hook that wires state to the helpers; API unchanged
- `web/src/index.css`: `::view-transition-old(root)` / `new(root)` duration override

## Test plan
- [x] `cd web && npm install` succeeds
- [x] `cd web && npm run build` passes (49.94 kB main JS, 14.52 kB CSS)
- [x] `cd web && npm run lint` passes
- [ ] Visual smoke test: `npm run dev` -> theme toggle cross-fades on Chromium, snaps instantly under `prefers-reduced-motion: reduce`

## Breaking changes
None — `useTheme()` call shape unchanged.

## Rollback plan
Revert the PR.