### PR TITLE
feat(web): add cn() className merge helper

### DIFF
--- a/web/src/lib/cn.ts
+++ b/web/src/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
Closes #18

## Summary
Add `web/src/lib/cn.ts` exporting `cn(...inputs)` that pipes clsx through tailwind-merge. Standard shadcn-style utility the rest of the component work assumes.

## Why
Link to issue #18. Centralized helper so conflicting Tailwind utilities (e.g. base `px-4` overridden by `px-6`) resolve correctly and component authors write `cn()` instead of ad-hoc template-literal concat.

## Changes
- `web/src/lib/cn.ts`: `cn(...inputs: ClassValue[])`

## Test plan
- [x] `cd web && npm run build` passes (no delta — tree-shaken until consumers land)
- [x] `cd web && npm run lint` passes
- [ ] Visual smoke test: unchanged; helper has no runtime effect yet

## Breaking changes
None.

## Rollback plan
Revert the PR.