### PR TITLE
feat(web): migrate predict API base to VITE_API_BASE_URL

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+# Backend HTTP API base URL. Override per environment.
+VITE_API_BASE_URL=http://localhost:8080

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment files (Vite). Keep .env.example tracked.
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web/src/api/predict.ts
+++ b/web/src/api/predict.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE = 'http://localhost:8080';
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080';
 
 export interface PredictionResponse {
   prediction: number;


### PR DESCRIPTION
Closes #16

## Summary
Read `API_BASE` from `import.meta.env.VITE_API_BASE_URL` with the existing `http://localhost:8080` default, add `web/.env.example`, and harden `web/.gitignore` so real `.env*` files stay out while `.env.example` is tracked.

## Why
Link to issue #16. Vercel/preview deployments need the backend URL to come from build-time env, not hardcoded source.

## Changes
- `web/src/api/predict.ts`: `const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'`
- `web/.env.example`: document the single required env var
- `web/.gitignore`: add `.env`, `.env.*` with `!.env.example` negation

## Test plan
- [x] `cd web && npm install` succeeds (unchanged deps)
- [x] `cd web && npm run build` passes; grep of main bundle confirms localhost default is inlined when no env
- [x] `cd web && npm run lint` passes
- [x] `git check-ignore web/.env web/.env.production` -> ignored; `web/.env.example` -> tracked
- [ ] Visual smoke test: `npm run dev` -> API calls still hit localhost:8080

## Breaking changes
None (fallback preserves current behavior).

## Rollback plan
Revert the PR.