### PR TITLE
feat(web): add vercel.json SPA rewrite

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
Closes #17

## Summary
Add `web/vercel.json` with a catch-all `/(.*)` -> `/` rewrite so deep-linked URLs render through `index.html` instead of 404-ing on Vercel's edge.

## Why
Link to issue #17. SPA rewrite is a prerequisite for the first preview deploy to serve non-root paths.

## Changes
- `web/vercel.json`: `$schema` + single rewrite rule

## Test plan
- [x] JSON parses (`python3 -c 'import json; json.load(open("web/vercel.json"))'`)
- [x] `cd web && npm run build` passes
- [x] `cd web && npm run lint` passes
- [ ] Post-deploy: hit a deep link on the preview URL and confirm `index.html` is served

## Breaking changes
None (new file; no runtime behavior changes locally).

## Rollback plan
Revert the PR.