### PR TITLE
docs(hygiene): add FUNDING.yml placeholder

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Funding links shown on the repo sidebar.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# TODO: enable once GitHub Sponsors is approved for @yadava5.
+# github: [yadava5]


### PR DESCRIPTION
Closes #8

## Summary
Adds a commented-out FUNDING.yml placeholder so the slot exists and a single-line edit enables the Sponsor button later.

## Why
Issue #8. Low-friction reserve.

## Changes
- New `.github/FUNDING.yml` with GitHub Sponsors line commented out + TODO note.

## Test plan
- [x] YAML parses (commented-only file, zero keys)
- [x] No Sponsor button visible until the line is uncommented (intended)

## Breaking changes
None.

## Rollback plan
Revert the PR.