### PR TITLE
chore(hygiene): ignore .DS_Store, commit .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(glab ci get *)",
+      "Bash(glab mr view *)",
+      "Bash(glab ci status *)",
+      "Bash(glab issue view *)",
+      "Bash(glab issue list *)",
+      "Bash(npm run test)",
+      "Bash(npm run lint)",
+      "Bash(glab mr list *)",
+      "Bash(glab ci trace *)",
+      "Bash(glab label list *)",
+      "Bash(glab ci list *)",
+      "Bash(gh run watch *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,13 @@ test_model
 fast_mnist_cli
 fast_mnist_server
 fast_mnist_trainer
+
+# macOS
+.DS_Store
+
+# Claude Code workspace
+# - .claude/settings.json is tracked (project permission allowlist)
+# - .claude/settings.local.json is machine-specific
+# - .claude/worktrees/ is agent ephemeral
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Closes #9

## Summary
Tightens .gitignore to exclude .DS_Store and machine-local Claude Code files while tracking the project-wide permission allowlist (`.claude/settings.json`).

## Why
Issue #9. Removes recurring accidental-commit vector for .DS_Store; makes the repo's shared Claude Code permission allowlist travel with the repo (useful for every contributor + CI run); keeps machine-specific overrides and the ephemeral agent worktree cache out.

## Changes
- .gitignore: append .DS_Store, .claude/settings.local.json, .claude/worktrees/ (with explanatory comment).
- New tracked file: .claude/settings.json (12-entry permission allowlist for glab, gh run watch, npm run test/lint).

## Test plan
- [x] `git check-ignore -v .DS_Store` → matched
- [x] `git check-ignore -v .claude/settings.json` → NOT matched (tracked)
- [x] `git check-ignore -v .claude/worktrees/foo` → matched
- [x] JSON file parses

## Breaking changes
None.

## Rollback plan
Revert the PR.