### PR TITLE
feat(frontend): add useReducedMotion hook wrapper

### DIFF
--- a/web/src/hooks/useReducedMotion.ts
+++ b/web/src/hooks/useReducedMotion.ts
@@ -1,0 +1,10 @@
+import { useReducedMotion as useMotionReducedMotion } from 'motion/react';
+
+/**
+ * Wrapper around Motion's useReducedMotion so every consumer has one
+ * import path. Returns `true` when the user has requested reduced motion
+ * at the OS level.
+ */
+export function useReducedMotion(): boolean {
+  return !!useMotionReducedMotion();
+}


### PR DESCRIPTION
Closes #20

## Summary
Adds `web/src/hooks/useReducedMotion.ts`, a thin wrapper around Motion's `useReducedMotion` that coerces its nullable return value to a plain boolean and gives every consumer one import path.

## Why
Phase 2 scaffolds (`ThemeToggle`, `NeuralNetHero`, command palette) all need to respect the OS reduced-motion preference. Centralising the hook keeps the API consistent across the tree.

## Changes
- `web/src/hooks/useReducedMotion.ts` (new) — re-exports and `!!`-coerces `motion/react`'s hook.

## Test plan
- [x] `cd web && npm install` succeeds
- [x] `cd web && npm run build` passes (tsc + vite build clean)
- [x] `cd web && npm run lint` passes
- [ ] Visual smoke test — not applicable, hook is consumed by later PRs

## Breaking changes
None.

## Rollback plan
Revert the PR.