### PR TITLE
feat(viz): scaffold NeuralNetHero lazy-load wrapper + poster

### DIFF
--- a/web/public/hero-poster.svg
+++ b/web/public/hero-poster.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-label="Neural net hero placeholder">
+  <rect width="400" height="400" fill="oklch(0.16 0.018 260)"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central"
+        fill="oklch(0.7 0.22 280)" font-family="Geist, system-ui, sans-serif"
+        font-size="120" font-weight="500">nn</text>
+</svg>

--- a/web/src/components/NeuralNetHero.Scene.tsx
+++ b/web/src/components/NeuralNetHero.Scene.tsx
@@ -1,0 +1,20 @@
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+
+export default function NeuralNetHeroScene() {
+  return (
+    <Canvas
+      dpr={[1, 1.75]}
+      camera={{ position: [3, 1.5, 4], fov: 45 }}
+      gl={{ powerPreference: 'high-performance', antialias: false }}
+    >
+      <ambientLight intensity={0.4} />
+      <directionalLight position={[5, 5, 5]} intensity={1.2} />
+      <mesh>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="oklch(0.7 0.22 280)" />
+      </mesh>
+      <OrbitControls enablePan={false} enableZoom={false} />
+    </Canvas>
+  );
+}

--- a/web/src/components/NeuralNetHero.tsx
+++ b/web/src/components/NeuralNetHero.tsx
@@ -1,0 +1,54 @@
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { cn } from '../lib/cn';
+
+const Scene = lazy(() => import('./NeuralNetHero.Scene'));
+
+interface Props {
+  className?: string;
+}
+
+export function NeuralNetHero({ className }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  useEffect(() => {
+    if (shouldLoad) return;
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          const start = () => setShouldLoad(true);
+          if ('requestIdleCallback' in window) {
+            (window as unknown as { requestIdleCallback: (cb: () => void) => void }).requestIdleCallback(start);
+          } else {
+            setTimeout(start, 0);
+          }
+          io.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [shouldLoad]);
+
+  return (
+    <div
+      ref={ref}
+      className={cn('relative aspect-square w-full max-w-lg', className)}
+    >
+      <img
+        src="/hero-poster.svg"
+        alt=""
+        aria-hidden
+        className="absolute inset-0 h-full w-full object-contain opacity-80"
+      />
+      {shouldLoad && (
+        <Suspense fallback={null}>
+          <Scene />
+        </Suspense>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #19

## Summary
Adds the `NeuralNetHero` IntersectionObserver + `React.lazy` wrapper, a minimal `NeuralNetHero.Scene` r3f stub that the wrapper dynamically imports, and a placeholder `hero-poster.svg` so the hero area never shows blank space. App.tsx wire-up is intentionally deferred to a later "wire Phase 2 components" PR.

## Why
`three` + `@react-three/fiber` pulls ~780 kB gzip. We don't want that in the critical path or even in the initial async graph. Poster image plus a viewport-triggered lazy mount keeps LCP intact and only pays the three cost on scroll.

## Changes
- `web/src/components/NeuralNetHero.Scene.tsx` (new) — minimal Canvas with lights, cube, restricted OrbitControls; default export so `React.lazy` can dynamic-import it
- `web/src/components/NeuralNetHero.tsx` (new) — IntersectionObserver (`rootMargin: 200px`) + `requestIdleCallback` gate for the lazy mount; Suspense fallback=null since poster is underneath
- `web/public/hero-poster.svg` (new) — 400x400 `nn` monogram placeholder

## Test plan
- [x] `cd web && npm install` succeeds
- [x] `cd web && npm run build` passes (tsc + vite build clean; `three-vendor` chunk still 778 kB gzip, unchanged)
- [x] `cd web && npm run lint` passes
- [ ] Visual smoke test — owner to verify after the wire-up PR lands

## Breaking changes
None. Components are exported but not imported yet.

## Rollback plan
Revert the PR.