### PR TITLE
fix(hygiene): relax commitlint body/footer rules

### DIFF
--- a/web/commitlint.config.mjs
+++ b/web/commitlint.config.mjs
@@ -2,26 +2,57 @@
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    // Subject: keep the 72-char cap (Linux-kernel convention, good for git log).
     'header-max-length': [2, 'always', 72],
+
+    // Disable body/footer line caps — we write long URLs in VALIDATION
+    // sections and the default 100-char limit fails on real URLs.
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
+
+    // Blank-line rules: warn, don't block. Squash merges can collapse
+    // the leading blank line between body and footer; not worth failing
+    // the build over.
+    'body-leading-blank': [1, 'always'],
+    'footer-leading-blank': [1, 'always'],
+
+    // Type must be one of these.
     'type-enum': [
       2,
       'always',
       ['feat', 'fix', 'perf', 'chore', 'docs', 'refactor', 'test', 'build', 'ci', 'style'],
     ],
+
+    // Scope is a soft suggestion (level 1 = warning). Expanded to cover
+    // the organic set we've used so far so existing commits are silent.
     'scope-enum': [
       1,
       'always',
       [
+        // tracks
         'frontend',
         'backend',
         'optimization',
         'hygiene',
+        // areas
         'docs',
         'viz',
         'canvas',
+        'web',
+        // infra
         'ci',
         'deps',
         'release',
+        'github',
+        'automation',
+        'security',
+        'meta',
+        'hooks',
+        'deploy',
+        'theme',
+        'utils',
+        'components',
+        'scaffolds',
       ],
     ],
   },


### PR DESCRIPTION
## Summary
`@commitlint/config-conventional` defaults `body-max-line-length` to 100 chars at error level, which fails on real URLs in our VALIDATION sections. Also expands scope-enum to cover the organic scopes we've actually been using.

## Why
PR #41 (hygiene → main major merge) failed the Lint commit messages check because two commits in PR #37 cite URLs that exceed 100 chars. Rewriting merged commits is undesirable; relaxing the rule fits our commit style.

## Changes
- `body-max-line-length`: off (was level 2 error at 100)
- `footer-max-line-length`: off
- `body-leading-blank` + `footer-leading-blank`: warning (was error)
- `scope-enum`: expanded, still warning-level

## Test plan
- [x] Local smoke test parses PR #37 squash body cleanly
- [ ] Commitlint CI passes on this PR
- [ ] Commitlint CI passes on PR #41 after this merges (via auto-update)

## Breaking changes
None. Policy stays strict on type + header length.

## Rollback plan
Revert the PR.