### PR TITLE
fix(hygiene): bump commitlint header-max-length to 80

### DIFF
--- a/web/commitlint.config.mjs
+++ b/web/commitlint.config.mjs
@@ -2,8 +2,10 @@
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    // Subject: keep the 72-char cap (Linux-kernel convention, good for git log).
-    'header-max-length': [2, 'always', 72],
+    // Subject: cap at 80 to leave room for GitHub's auto-appended " (#N)"
+    // suffix on squash merges. Hand-written subjects still target ~66 chars
+    // to stay comfortably under the cap after squashing.
+    'header-max-length': [2, 'always', 80],
 
     // Disable body/footer line caps — we write long URLs in VALIDATION
     // sections and the default 100-char limit fails on real URLs.


### PR DESCRIPTION
## Summary
Raise commitlint header-max-length cap from 72 to 80 so GitHub's auto-appended ` (#N)` squash-merge suffix doesn't push otherwise-compliant subjects over the limit.

## Why
PR #41 commitlint CI fails on two commits (#46, #47) whose subjects are 73 chars after squash. Root cause: hand-written subjects ~66 chars + ` (#NN)` = 73. Cap at 80 gives 8 chars of headroom (enough for 6-digit PR numbers).

## Changes
- `web/commitlint.config.mjs`: `'header-max-length': [2, 'always', 80]`

## Test plan
- [ ] Commitlint CI on this PR passes
- [ ] Commitlint CI on PR #41 passes after this merges

## Breaking changes
None.

## Rollback plan
Revert the PR.