### PR TITLE
feat(frontend): wire Phase 2 scaffolds into App.tsx

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -460,3 +460,99 @@ body {
   background: #667eea;
   box-shadow: 0 0 8px rgba(102, 126, 234, 0.5);
 }
+
+/* === Phase 2: hero section + cmdk hint === */
+
+.hero-section {
+  display: grid;
+  grid-template-columns: 1fr minmax(0, 1.2fr);
+  gap: 3rem;
+  align-items: center;
+  padding: 3rem 2rem 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-title {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  margin: 0;
+  background: linear-gradient(90deg, var(--text-primary, #fff) 0%, #8b7cff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.hero-subtitle {
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  max-width: 32ch;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.hero-visual {
+  aspect-ratio: 1;
+  width: 100%;
+  max-width: 480px;
+  justify-self: end;
+  position: relative;
+}
+
+.hero-visual > * {
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 900px) {
+  .hero-section {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding: 2rem 1rem;
+  }
+
+  .hero-visual {
+    justify-self: center;
+    max-width: 360px;
+  }
+}
+
+.cmdk-hint {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.4));
+  margin: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  pointer-events: none;
+}
+
+.cmdk-hint kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.4em;
+  height: 1.4em;
+  padding: 0 0.35em;
+  border-radius: 4px;
+  border: 1px solid var(--surface-border, rgba(255, 255, 255, 0.15));
+  background: var(--surface-bg, rgba(255, 255, 255, 0.05));
+  font-size: 0.7rem;
+  font-family: inherit;
+  line-height: 1;
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { DrawingCanvas } from './components/DrawingCanvas';
 import { PredictionResult } from './components/PredictionResult';
 import { NeuralNetViz } from './components/NeuralNetViz';
 import { ThemeToggle } from './components/ThemeToggle';
+import { NeuralNetHero } from './components/NeuralNetHero';
+import { CommandPalette } from './components/CommandPalette';
 import { predict, healthCheck } from './api/predict';
 import { useTheme } from './hooks/useTheme';
 import { useDebouncedCallback } from './hooks/useDebounce';
@@ -19,7 +21,7 @@ function App() {
   const [isLoading, setIsLoading] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [serverStatus, setServerStatus] = useState<'checking' | 'online' | 'offline'>('checking');
-  
+
   const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -37,17 +39,14 @@ function App() {
   }, []);
 
   const performPrediction = useCallback(async (pixels: number[]) => {
-    // Cancel any pending request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
-    
-    // Create new AbortController for this request
     abortControllerRef.current = new AbortController();
-    
+
     setIsLoading(true);
     setIsAnimating(true);
-    
+
     try {
       const result = await predict(pixels, abortControllerRef.current.signal);
       setPrediction(result.prediction);
@@ -55,23 +54,17 @@ function App() {
       setBaselineTime(result.baseline_time_ms);
       setOptimizedTime(result.optimized_time_ms);
     } catch (error) {
-      // Don't log abort errors - they're intentional
       if (error instanceof Error && error.name === 'CanceledError') {
         return;
       }
       console.error('Prediction failed:', error);
     } finally {
       setIsLoading(false);
-      // Keep animation running a bit longer for effect
       setTimeout(() => setIsAnimating(false), 300);
     }
   }, []);
 
-  // Debounced prediction handler (300ms delay)
-  const { debouncedFn: handlePredict } = useDebouncedCallback(
-    performPrediction,
-    300
-  );
+  const { debouncedFn: handlePredict } = useDebouncedCallback(performPrediction, 300);
 
   return (
     <div className="app">
@@ -87,12 +80,28 @@ function App() {
           {serverStatus === 'online' && 'Server Online'}
           {serverStatus === 'offline' && 'Server Offline - Start the backend'}
         </div>
+        <p className="cmdk-hint" aria-hidden>
+          <kbd>⌘</kbd>
+          <kbd>K</kbd> for commands
+        </p>
       </header>
+
+      <section className="hero-section">
+        <div className="hero-copy">
+          <h2 className="hero-title">784 → 100 → 10</h2>
+          <p className="hero-subtitle">
+            A handwritten C++ multilayer perceptron with SIMD kernels and OpenMP, visualized.
+          </p>
+        </div>
+        <div className="hero-visual">
+          <NeuralNetHero />
+        </div>
+      </section>
 
       <main className="main-content">
         <div className="canvas-section">
           <h2>✏️ Draw Here</h2>
-          <DrawingCanvas 
+          <DrawingCanvas
             onPredict={handlePredict}
             disabled={serverStatus !== 'online'}
             isLoading={isLoading}
@@ -117,13 +126,11 @@ function App() {
       </main>
 
       <footer className="footer">
-        <p>
-          Built with C++ • SIMD Optimizations • OpenMP Parallelization
-        </p>
-        <p className="author">
-          By Ayush Yadav • Contributor: Shree Chaturvedi
-        </p>
+        <p>Built with C++ · SIMD kernels · OpenMP · Motion · React Three Fiber</p>
+        <p className="author">By Ayush Yadav · Contributor: Shree Chaturvedi</p>
       </footer>
+
+      <CommandPalette />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Mounts `<NeuralNetHero>` as a new hero section between header and main, and `<CommandPalette>` as a sibling of everything so ⌘K opens the palette from anywhere. Adds a subtle ⌘K hint in the header.

## Changes
- `web/src/App.tsx`: new imports + `<section.hero-section>` slot + `<CommandPalette />` mount + ⌘K hint
- `web/src/App.css`: `.hero-section` (responsive grid), `.hero-title` (gradient monospace clamp font), `.hero-subtitle`, `.hero-visual` (aspect-ratio 1), `.cmdk-hint` + kbd styles

## Test plan
- [x] `cd web && npm run build` passes (main bundle 258 KB, NeuralNetHero.Scene lazy chunk 0.5 KB, three-vendor lazy 2.6 MB)
- [x] `cd web && npm run lint` clean
- [ ] Visual: 3D stub visible on hero, ⌘K opens palette, hero collapses below 900px — verify in preview

## Why
Closes the Phase 2 scaffolding arc. Components existed on frontend since PRs #42–#45 but weren't mounted.

## Follow-ups
- Replace `NeuralNetHero.Scene.tsx` stub with real 4-layer architecture + scroll-linked camera (next PR, 14h agent work)
- Replace decorative `NeuralNetViz` with real activation heatmap + saliency (Phase 4, requires backend change)
- Paper-shaders MeshGradient hero backdrop + framer.com parallax (Phase 2 continuation)

## Rollback plan
Revert the PR.