### PR TITLE
feat(viz): real revolvable 3D neural-net architecture hero

### DIFF
--- a/web/src/components/NeuralNetHero.Layers.tsx
+++ b/web/src/components/NeuralNetHero.Layers.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import * as THREE from 'three';
+import { Instance, Instances } from '@react-three/drei';
+
+interface LayerProps {
+  positions: [number, number, number][];
+  radius: number;
+  color: string;
+  emissive: string;
+  emissiveIntensity: number;
+}
+
+/**
+ * Render a single neural-net layer as an instanced mesh of spheres.
+ * drei's <Instances> keeps this cheap even for 196+ nodes.
+ */
+export function Layer({ positions, radius, color, emissive, emissiveIntensity }: LayerProps) {
+  return (
+    <Instances limit={positions.length} range={positions.length}>
+      <sphereGeometry args={[radius, 12, 12]} />
+      <meshStandardMaterial
+        color={color}
+        emissive={emissive}
+        emissiveIntensity={emissiveIntensity}
+        roughness={0.35}
+        metalness={0.1}
+      />
+      {positions.map((p, i) => (
+        <Instance key={i} position={p} />
+      ))}
+    </Instances>
+  );
+}
+
+interface EdgesProps {
+  from: [number, number, number][];
+  to: [number, number, number][];
+  count: number;
+  color: string;
+}
+
+/**
+ * Sample `count` edges between two layers and render them as thin cylinders.
+ * We pick endpoints pseudo-randomly but deterministically so the scene looks
+ * consistent across renders.
+ */
+export function Edges({ from, to, count, color }: EdgesProps) {
+  const edges = useMemo(() => {
+    // deterministic LCG so edges don't jitter between re-renders
+    let seed = 1337;
+    const rand = () => {
+      seed = (seed * 1664525 + 1013904223) % 4294967296;
+      return seed / 4294967296;
+    };
+    const out: { position: THREE.Vector3; quaternion: THREE.Quaternion; length: number }[] = [];
+    const upAxis = new THREE.Vector3(0, 1, 0);
+    for (let i = 0; i < count; i += 1) {
+      const a = from[Math.floor(rand() * from.length)];
+      const b = to[Math.floor(rand() * to.length)];
+      const va = new THREE.Vector3(...a);
+      const vb = new THREE.Vector3(...b);
+      const dir = new THREE.Vector3().subVectors(vb, va);
+      const length = dir.length();
+      const mid = new THREE.Vector3().addVectors(va, vb).multiplyScalar(0.5);
+      const q = new THREE.Quaternion().setFromUnitVectors(upAxis, dir.clone().normalize());
+      out.push({ position: mid, quaternion: q, length });
+    }
+    return out;
+  }, [from, to, count]);
+
+  return (
+    <Instances limit={edges.length} range={edges.length}>
+      <cylinderGeometry args={[0.006, 0.006, 1, 6, 1]} />
+      <meshBasicMaterial color={color} transparent opacity={0.35} />
+      {edges.map((e, i) => (
+        <Instance
+          key={i}
+          position={e.position}
+          quaternion={e.quaternion}
+          scale={[1, e.length, 1]}
+        />
+      ))}
+    </Instances>
+  );
+}

--- a/web/src/components/NeuralNetHero.Scene.tsx
+++ b/web/src/components/NeuralNetHero.Scene.tsx
@@ -1,20 +1,118 @@
-import { Canvas } from '@react-three/fiber';
+import { useMemo, useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
+import type { Group } from 'three';
+import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import { Edges, Layer } from './NeuralNetHero.Layers';
+import { gridPositions } from '../lib/layout';
+import { GlassBackdrop } from './NeuralNetHero.glass';
+
+const EDGE_COLOR = 'oklch(0.5 0.05 260)';
+
+/**
+ * Auto-rotate the scene around Y when the user is not actively dragging.
+ * Reads the OrbitControls azimuth to detect user interaction; when it has
+ * been idle (no change) for a short window, spins the root group slowly.
+ */
+function AutoRotate({
+  rootRef,
+  controlsRef,
+  disabled,
+}: {
+  rootRef: React.RefObject<Group | null>;
+  controlsRef: React.RefObject<OrbitControlsImpl | null>;
+  disabled: boolean;
+}) {
+  const lastAzimuth = useRef<number | null>(null);
+  const idleTime = useRef(0);
+
+  useFrame((_, delta) => {
+    if (disabled) return;
+    const root = rootRef.current;
+    const controls = controlsRef.current;
+    if (!root || !controls) return;
+
+    const az = controls.getAzimuthalAngle();
+    if (lastAzimuth.current === null) lastAzimuth.current = az;
+    const moved = Math.abs(az - lastAzimuth.current) > 1e-4;
+    lastAzimuth.current = az;
+
+    if (moved) {
+      idleTime.current = 0;
+      return;
+    }
+    // brief grace period so damping finishes before auto-rotate kicks in
+    idleTime.current += delta;
+    if (idleTime.current < 0.4) return;
+    root.rotation.y += delta * 0.1;
+  });
+  return null;
+}
 
 export default function NeuralNetHeroScene() {
+  const reduced = useReducedMotion();
+  const rootRef = useRef<Group>(null);
+  const controlsRef = useRef<OrbitControlsImpl>(null);
+
+  // Layer geometry. Z spacing places the backdrop at -2.5, input at -1.2,
+  // hidden at 0, output at 1.2.
+  const { input, hidden, output } = useMemo(() => {
+    return {
+      input: gridPositions(14, 14, 2.8, 2.8, -1.2),
+      hidden: gridPositions(10, 10, 2.2, 2.2, 0),
+      output: gridPositions(1, 10, 0, 2.4, 1.2),
+    };
+  }, []);
+
   return (
     <Canvas
       dpr={[1, 1.75]}
       camera={{ position: [3, 1.5, 4], fov: 45 }}
       gl={{ powerPreference: 'high-performance', antialias: false }}
+      frameloop={reduced ? 'demand' : 'always'}
     >
       <ambientLight intensity={0.4} />
       <directionalLight position={[5, 5, 5]} intensity={1.2} />
-      <mesh>
-        <boxGeometry args={[1, 1, 1]} />
-        <meshStandardMaterial color="oklch(0.7 0.22 280)" />
-      </mesh>
-      <OrbitControls enablePan={false} enableZoom={false} />
+
+      <group ref={rootRef}>
+        <GlassBackdrop />
+
+        <Layer
+          positions={input}
+          radius={0.055}
+          color="oklch(0.7 0.1 220)"
+          emissive="oklch(0.5 0.15 220)"
+          emissiveIntensity={0.25}
+        />
+        <Layer
+          positions={hidden}
+          radius={0.07}
+          color="oklch(0.7 0.22 280)"
+          emissive="oklch(0.5 0.2 280)"
+          emissiveIntensity={0.25}
+        />
+        <Layer
+          positions={output}
+          radius={0.11}
+          color="oklch(0.7 0.22 280)"
+          emissive="oklch(0.5 0.2 280)"
+          emissiveIntensity={0.4}
+        />
+
+        <Edges from={input} to={hidden} count={60} color={EDGE_COLOR} />
+        <Edges from={hidden} to={output} count={30} color={EDGE_COLOR} />
+      </group>
+
+      <AutoRotate rootRef={rootRef} controlsRef={controlsRef} disabled={reduced} />
+
+      <OrbitControls
+        ref={controlsRef}
+        enablePan={false}
+        enableZoom={false}
+        enableDamping={!reduced}
+        dampingFactor={0.08}
+      />
     </Canvas>
   );
 }

--- a/web/src/components/NeuralNetHero.glass.tsx
+++ b/web/src/components/NeuralNetHero.glass.tsx
@@ -1,0 +1,24 @@
+import { MeshTransmissionMaterial } from '@react-three/drei';
+
+/**
+ * Frosted-glass backdrop panel behind the neural-net scene.
+ * Sits at z = -2.5 and subtly refracts the nodes/edges in front of it.
+ */
+export function GlassBackdrop() {
+  return (
+    <mesh position={[0, 0, -2.5]}>
+      <planeGeometry args={[6, 4]} />
+      <MeshTransmissionMaterial
+        thickness={0.3}
+        roughness={0.1}
+        transmission={1}
+        ior={1.4}
+        chromaticAberration={0.04}
+        backside
+        backsideResolution={256}
+        samples={6}
+        color="oklch(0.85 0.08 280)"
+      />
+    </mesh>
+  );
+}

--- a/web/src/lib/layout.ts
+++ b/web/src/lib/layout.ts
@@ -1,0 +1,23 @@
+/**
+ * Compute node positions for a rectangular grid laid out on the X/Y plane
+ * at a fixed Z depth. Used by the 3D neural-net hero to place layer nodes.
+ */
+export function gridPositions(
+  cols: number,
+  rows: number,
+  width: number,
+  height: number,
+  z: number,
+): [number, number, number][] {
+  const positions: [number, number, number][] = [];
+  const xStep = cols > 1 ? width / (cols - 1) : 0;
+  const yStep = rows > 1 ? height / (rows - 1) : 0;
+  const x0 = -width / 2;
+  const y0 = -height / 2;
+  for (let r = 0; r < rows; r += 1) {
+    for (let c = 0; c < cols; c += 1) {
+      positions.push([x0 + c * xStep, y0 + r * yStep, z]);
+    }
+  }
+  return positions;
+}


### PR DESCRIPTION
## Summary

Replace the cube stub in `NeuralNetHero.Scene.tsx` with the full 4-plane neural-net architecture hero:

- **Glass backdrop** at z = -2.5 (`MeshTransmissionMaterial`, violet tint).
- **Input layer** — 14x14 = 196 instanced spheres at z = -1.2, cyan.
- **Hidden layer** — 10x10 = 100 instanced spheres at z = 0, violet.
- **Output layer** — 1x10 = 10 larger, brighter violet spheres at z = 1.2.
- **Edges**: 60 sampled connectors input->hidden, 30 hidden->output (deterministic LCG, cylinder-instanced, muted `oklch(0.5 0.05 260)`).
- **Interaction**: `<OrbitControls>` pan/zoom disabled, damping 0.08. Auto-rotates ~0.1 rad/s on Y when the azimuth has been idle ~0.4 s; user drag immediately cancels.
- **Reduced motion**: `Canvas frameloop="demand"`, damping off, auto-rotate disabled; drag-to-rotate still works.

Scene files are split for clarity (all < 200 lines):
- `web/src/components/NeuralNetHero.Scene.tsx` — Canvas + composition.
- `web/src/components/NeuralNetHero.Layers.tsx` — `<Layer>` + `<Edges>` instanced components.
- `web/src/components/NeuralNetHero.glass.tsx` — frosted backdrop.
- `web/src/lib/layout.ts` — `gridPositions` helper (kept outside the component file so `react-refresh/only-export-components` stays happy).

Scroll-linked camera intentionally deferred: spec allowed a static camera at `[3, 1.5, 4]` and I took that path to keep this PR focused. Follow-up can wire Motion v12 `useScroll` / `useSpring` without restructuring.

## Bundle impact

Main `index` chunk: **205.65 kB (gzip 69.41 kB)** — unchanged vs `frontend`. The new Scene code lands in the lazy async chunk (`three.module-*.js`, 12.78 kB / gzip 4.85 kB) so the initial page load is unaffected. `three-vendor` chunk still splits at 2,608.30 kB / gzip 778.54 kB.

## Test plan

- [x] `cd web && npm run lint` — clean.
- [x] `cd web && npm run build` — succeeds, bundle sizes as above.
- [ ] `npm run dev` visual check (not exercised from agent sandbox; owner to spin up dev server and confirm): scene loads after IntersectionObserver fires, drag rotates, releasing resumes slow auto-rotation, `prefers-reduced-motion: reduce` freezes auto-motion but keeps drag.
- [ ] Mobile/Safari quick check for `MeshTransmissionMaterial` performance — if the frosted plane is too heavy we can drop `samples` from 6 to 4 or swap to `meshPhysicalMaterial` with transmission.

Do not merge — leaving open for owner review.