### PR TITLE
feat(backend): /predict returns hidden_activations + input_grad

### DIFF
--- a/apps/server.cpp
+++ b/apps/server.cpp
@@ -233,14 +233,26 @@ int main(int argc, char* argv[]) {
             for (int i = 0; i < 10; ++i) {
                 confidence[i] /= sum;
             }
-            
+
+            // Per-request interpretability: hidden activations +
+            // input-pixel saliency for the predicted class. These
+            // run ONCE (not in the timing loop) so they do not
+            // pollute baseline_time_ms / optimized_time_ms.
+            std::vector<double> hiddenActivations;
+            g_network.classifyWithHidden(input, hiddenActivations);
+
+            std::vector<double> inputGrad;
+            g_network.computeInputGradient(input, prediction, inputGrad);
+
             json response = {
                 {"prediction", prediction},
                 {"confidence", confidence},
                 {"baseline_time_ms", baselineTime},
-                {"optimized_time_ms", optimizedTime}
+                {"optimized_time_ms", optimizedTime},
+                {"hidden_activations", hiddenActivations},
+                {"input_grad", inputGrad}
             };
-            
+
             res.set_content(response.dump(), "application/json");
             
         } catch (const json::parse_error& e) {

--- a/include/fast_mnist/NeuralNet.h
+++ b/include/fast_mnist/NeuralNet.h
@@ -123,6 +123,28 @@ class NeuralNet {
                               std::vector<Val>& hiddenActivations) const;
 
     /**
+     * Compute the gradient of the predicted class's output
+     * activation with respect to the input pixels, for saliency
+     * visualization. Uses plain backpropagation through sigmoid
+     * activations. Does NOT modify weights or biases.
+     *
+     * For a 2-layer network the math is:
+     *   a1 = sigmoid(W0 * x + b0),  a2 = sigmoid(W1 * a1 + b1)
+     *   delta2  = e_target * a2 * (1 - a2)   (e_target = one-hot)
+     *   delta1  = (W1^T * delta2) .* a1 * (1 - a1)
+     *   grad_x  = W0^T * delta1
+     *
+     * \param[in] inputs Column-vector of input values.
+     * \param[in] targetClass Output-neuron index whose activation
+     * gradient to take -- typically argmax of the forward pass.
+     * \param[out] grad std::vector<Val> resized to the input
+     * dimension and filled with gradient values.
+     */
+    void computeInputGradient(const Matrix& inputs,
+                              int targetClass,
+                              std::vector<Val>& grad) const;
+
+    /**
      * This method is the top-level training method that processes
      * multiple input images and calling the learn method in this
      * class.

--- a/include/fast_mnist/NeuralNet.h
+++ b/include/fast_mnist/NeuralNet.h
@@ -102,6 +102,27 @@ class NeuralNet {
     Matrix classify(const Matrix& inputs) const;
 
     /**
+     * Classify an input and return the hidden-layer activations
+     * alongside the output activations. For a 2-layer network
+     * (input -> hidden -> output), \c hiddenActivations is filled
+     * with the hidden-layer post-sigmoid values.
+     *
+     * Unlike classify(), this method does not use a static scratch
+     * buffer; it allocates per call so it is safe to invoke from
+     * multiple threads (e.g. concurrent HTTP requests).
+     *
+     * \param[in] inputs Column-vector of input values (e.g. 784
+     * pixel values in [0, 1]).
+     * \param[out] hiddenActivations std::vector<Val> that will be
+     * resized to match the hidden layer width and filled with
+     * post-sigmoid activations of the first hidden layer.
+     *
+     * \return Output-layer activations (same shape as classify()).
+     */
+    Matrix classifyWithHidden(const Matrix& inputs,
+                              std::vector<Val>& hiddenActivations) const;
+
+    /**
      * This method is the top-level training method that processes
      * multiple input images and calling the learn method in this
      * class.

--- a/src/NeuralNet.cpp
+++ b/src/NeuralNet.cpp
@@ -631,4 +631,60 @@ Matrix NeuralNet::classifyWithHidden(
     return out;
 }
 
+/*
+ * Compute d a2[targetClass] / d x using plain backpropagation
+ * through sigmoid activations. Follows the Nielsen formulation with
+ * the cost gradient replaced by a one-hot selector e_target, so the
+ * result is the gradient of the chosen output neuron's activation
+ * w.r.t. the raw input pixels -- the standard saliency map.
+ *
+ * Implementation uses plain nested loops; correctness and
+ * readability are prioritized over throughput since this runs once
+ * per HTTP request, not inside the inner training loop.
+ */
+void NeuralNet::computeInputGradient(const Matrix& inputs, int targetClass,
+                                     std::vector<Val>& grad) const {
+    // Forward pass -- recompute a1 (hidden) and a2 (output).
+    const std::size_t inputLen = weights[0].width();
+    const std::size_t hiddenLen = weights[0].height();
+    const std::size_t outputLen = weights[1].height();
+
+    Matrix a1(hiddenLen, 1, Matrix::NoInit{});
+    gemv_rowplusbias_sigmoid(weights[0], biases[0], inputs, a1);
+
+    Matrix a2(outputLen, 1, Matrix::NoInit{});
+    gemv_rowplusbias_sigmoid(weights[1], biases[1], a1, a2);
+
+    // delta2 = e_target .* a2 .* (1 - a2). Only the targetClass
+    // entry is non-zero since e_target is a one-hot vector.
+    std::vector<Val> delta2(outputLen, 0.0);
+    if (targetClass >= 0 &&
+        static_cast<std::size_t>(targetClass) < outputLen) {
+        const Val aT = a2[targetClass][0];
+        delta2[targetClass] = aT * (1.0 - aT);
+    }
+
+    // delta1 = (W1^T * delta2) .* a1 .* (1 - a1).
+    std::vector<Val> delta1(hiddenLen, 0.0);
+    for (std::size_t j = 0; j < hiddenLen; ++j) {
+        Val sum = 0.0;
+        for (std::size_t i = 0; i < outputLen; ++i) {
+            sum += weights[1][i][j] * delta2[i];
+        }
+        const Val aj = a1[j][0];
+        delta1[j] = sum * aj * (1.0 - aj);
+    }
+
+    // grad_input = W0^T * delta1. Input is raw pixels with no
+    // preceding sigmoid, so no derivative factor is applied here.
+    grad.assign(inputLen, 0.0);
+    for (std::size_t k = 0; k < inputLen; ++k) {
+        Val sum = 0.0;
+        for (std::size_t j = 0; j < hiddenLen; ++j) {
+            sum += weights[0][j][k] * delta1[j];
+        }
+        grad[k] = sum;
+    }
+}
+
 #endif

--- a/src/NeuralNet.cpp
+++ b/src/NeuralNet.cpp
@@ -602,4 +602,33 @@ Matrix NeuralNet::classify(const Matrix& inputs) const {
     return out;
 }
 
+/*
+ * Variant of classify() that also exposes the hidden layer
+ * activations. Allocates its own hidden buffer (no static state) so
+ * that concurrent callers -- e.g. multiple HTTP request threads --
+ * cannot observe each other's intermediate values. The small extra
+ * allocation is negligible on the per-request path, which is never
+ * benchmarked against the hot classify() loop.
+ */
+Matrix NeuralNet::classifyWithHidden(
+    const Matrix& inputs, std::vector<Val>& hiddenActivations) const {
+    // Non-static hidden buffer -- safe across threads.
+    const std::size_t hiddenLen = weights[0].height();
+    Matrix hidden(hiddenLen, 1, Matrix::NoInit{});
+
+    // Forward pass through first (hidden) layer.
+    gemv_rowplusbias_sigmoid(weights[0], biases[0], inputs, hidden);
+
+    // Copy hidden activations out for the caller.
+    hiddenActivations.resize(hiddenLen);
+    for (std::size_t i = 0; i < hiddenLen; ++i) {
+        hiddenActivations[i] = hidden[i][0];
+    }
+
+    // Forward pass through second (output) layer.
+    Matrix out(weights[1].height(), 1, Matrix::NoInit{});
+    gemv_rowplusbias_sigmoid(weights[1], biases[1], hidden, out);
+    return out;
+}
+
 #endif

--- a/tests/test_neural_net.cpp
+++ b/tests/test_neural_net.cpp
@@ -1,7 +1,9 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <cmath>
 #include <sstream>
+#include <vector>
 
 #include "fast_mnist/Matrix.h"
 #include "fast_mnist/NeuralNet.h"
@@ -18,6 +20,45 @@ std::string makeZeroNetStream() {
     Matrix b2(2, 1, 0.0);
     Matrix w1(2, 2, 0.0);
     Matrix w2(2, 2, 0.0);
+
+    std::ostringstream os;
+    os << layerSizes << '\n';
+    os << b1 << '\n';
+    os << b2 << '\n';
+    os << w1 << '\n';
+    os << w2 << '\n';
+    return os.str();
+}
+
+// Build a 2-3-2 network with small hand-picked weights so that the
+// forward pass produces predictable, non-trivial activations for
+// interpretability tests.
+std::string makeTinyNetStream() {
+    Matrix layerSizes(1, 3, 0.0);
+    layerSizes[0][0] = 2.0;
+    layerSizes[0][1] = 3.0;
+    layerSizes[0][2] = 2.0;
+
+    // Biases: one column per layer (hidden, output).
+    Matrix b1(3, 1, 0.0);
+    b1[0][0] = 0.1;
+    b1[1][0] = -0.2;
+    b1[2][0] = 0.05;
+
+    Matrix b2(2, 1, 0.0);
+    b2[0][0] = -0.1;
+    b2[1][0] = 0.2;
+
+    // W0: 3x2 (hidden x input).
+    Matrix w1(3, 2, 0.0);
+    w1[0][0] = 0.5;  w1[0][1] = -0.3;
+    w1[1][0] = 0.1;  w1[1][1] = 0.4;
+    w1[2][0] = -0.2; w1[2][1] = 0.7;
+
+    // W1: 2x3 (output x hidden).
+    Matrix w2(2, 3, 0.0);
+    w2[0][0] = 0.3;  w2[0][1] = -0.5; w2[0][2] = 0.2;
+    w2[1][0] = -0.1; w2[1][1] = 0.6;  w2[1][2] = 0.4;
 
     std::ostringstream os;
     os << layerSizes << '\n';
@@ -45,4 +86,72 @@ TEST_CASE("NeuralNet loads from stream", "[neural_net]") {
     REQUIRE(out.width() == 1);
     REQUIRE(out[0][0] == Catch::Approx(0.5));
     REQUIRE(out[1][0] == Catch::Approx(0.5));
+}
+
+TEST_CASE("classifyWithHidden exposes hidden activations",
+          "[neural_net][interpretability]") {
+    NeuralNet net({1, 1});
+    std::istringstream is(makeTinyNetStream());
+    is >> net;
+
+    Matrix input(2, 1, 0.0);
+    input[0][0] = 1.0;
+    input[1][0] = 0.0;
+
+    std::vector<Val> hidden;
+    Matrix out = net.classifyWithHidden(input, hidden);
+
+    // Hidden width matches the middle layer ({2, 3, 2}).
+    REQUIRE(hidden.size() == 3);
+    for (double h : hidden) {
+        REQUIRE(h > 0.0);
+        REQUIRE(h < 1.0);
+    }
+
+    // Output activations match the plain classify() path, confirming
+    // no drift between the two forward paths.
+    Matrix refOut = net.classify(input);
+    REQUIRE(out.height() == refOut.height());
+    REQUIRE(out[0][0] == Catch::Approx(refOut[0][0]));
+    REQUIRE(out[1][0] == Catch::Approx(refOut[1][0]));
+}
+
+TEST_CASE("computeInputGradient returns input-sized saliency",
+          "[neural_net][interpretability]") {
+    NeuralNet net({1, 1});
+    std::istringstream is(makeTinyNetStream());
+    is >> net;
+
+    Matrix input(2, 1, 0.0);
+    input[0][0] = 1.0;
+    input[1][0] = 0.0;
+
+    std::vector<Val> grad;
+    net.computeInputGradient(input, 0, grad);
+
+    REQUIRE(grad.size() == 2);
+
+    // For this hand-picked network the gradient must be non-zero in
+    // at least one component -- a trivial zero response would mean
+    // backprop is dropping the signal.
+    const bool anyNonZero =
+        std::abs(grad[0]) > 1e-12 || std::abs(grad[1]) > 1e-12;
+    REQUIRE(anyNonZero);
+
+    // Finite-difference sanity check: perturb each input pixel and
+    // compare (f(x+e) - f(x)) / eps against the analytic gradient
+    // of the class-0 output activation.
+    const double eps = 1e-6;
+    Matrix baseOut = net.classify(input);
+    for (int i = 0; i < 2; ++i) {
+        Matrix perturbed(2, 1, 0.0);
+        perturbed[0][0] = input[0][0];
+        perturbed[1][0] = input[1][0];
+        perturbed[i][0] += eps;
+        Matrix pOut = net.classify(perturbed);
+        const double fdGrad = (pOut[0][0] - baseOut[0][0]) / eps;
+        // Loose tolerance -- finite differences at 1e-6 on a
+        // sigmoid stack are typically accurate to ~1e-4.
+        REQUIRE(std::abs(grad[i] - fdGrad) < 5e-4);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `NeuralNet::classifyWithHidden()` (non-static hidden buffer, thread-safe) and `NeuralNet::computeInputGradient()` (plain backprop saliency) as NEW const public methods; existing `classify()`, `learn()`, `train()` and their hot-path static-hidden-buffer optimization are left untouched.
- `/predict` now appends `hidden_activations` (length == hidden width) and `input_grad` (length == 784) after the existing fields, so older clients keep working. The two calls run once per request, OUTSIDE the timing loops, so `baseline_time_ms` / `optimized_time_ms` are unchanged.
- Add Catch2 tests: shape + range checks on `classifyWithHidden`, and a finite-difference sanity check on `computeInputGradient` (within 5e-4 of the numerical gradient).

## Math
`computeInputGradient` implements the standard saliency backprop for a 2-layer sigmoid net: `delta2 = e_target * a2 * (1 - a2)` (one-hot selector for the predicted class), `delta1 = (W1^T * delta2) .* a1 * (1 - a1)`, `grad_x = W0^T * delta1`. Input layer carries no sigmoid, so no derivative factor is applied there.

## Test plan
- [x] `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`
- [x] `cmake --build build --config Release` clean, no new warnings
- [x] `ctest --test-dir build -C Release` 8/8 pass (6 existing + 2 new)
- [x] Local end-to-end probe: `./build/fast_mnist_server 8765 model.weights` + curl POST returned `hidden_activations` len 100 and `input_grad` len 784 with non-zero saliency (|max| ~ 0.39)
- [ ] CI: C++ build-test green on ubuntu / macos / windows