### PR TITLE
docs: rewrite README + extract BENCHMARKS + add 3 ADRs

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,161 @@
+# Benchmarks
+
+All numbers in this document are reproducible. Benchmarks are driven by
+[Google Benchmark](https://github.com/google/benchmark) via
+`benchmarks/bench_matrix.cpp`, orchestrated by `tools/run_benchmarks.py`,
+and published as JSON + CSV + SVG under `docs/benchmarks/`.
+
+## Methodology
+
+- **Harness.** Google Benchmark auto-selects iteration counts so each case
+  runs for at least 0.5 s of CPU time. Reported numbers are the mean
+  wall-clock nanoseconds per iteration across that window. Variance is
+  small enough (sub-percent on a quiet machine) that we don't publish
+  confidence intervals today; see *Continuous benchmarking* below for the
+  plan.
+- **Warm-up.** Google Benchmark's default pre-roll is sufficient for these
+  cache-resident workloads. The largest working set (a 1024×1024 float
+  matrix pair, ~8 MiB) exceeds L2 on M2; the smallest (32×32) fits in L1.
+- **Workloads.** `benchDot`, `benchTranspose`, and `benchAxpy` operate on
+  square matrices at N ∈ {32, 64, 128, 256, 512, 1024} using 64-byte
+  aligned storage and a padded leading dimension. `benchLearn` and
+  `benchClassify` exercise the full forward/backward path on a
+  784 → 30 → 10 network with deterministic input values (so any regression
+  is a real regression, not a sampling artefact).
+- **Release builds only.** Debug builds are never benchmarked.
+- **Three configurations.** baseline (no `-march=native`, no OpenMP),
+  `native` (`-march=native`, no OpenMP), and `openmp+native`. Each is a
+  clean CMake configure + build, not an incremental rebuild.
+
+## Reproducing
+
+```sh
+python3 tools/run_benchmarks.py --openmp --native
+```
+
+This runs all three configurations end-to-end, writes JSON into
+`docs/benchmarks/runs/`, appends a summary row to `bench_summary.csv`, and
+regenerates the SVG charts under `docs/benchmarks/charts/`. The Python
+driver shells out to CMake and Google Benchmark — no extra dependencies
+beyond the toolchain and `tqdm` (auto-installed).
+
+**CI note.** Continuous integration intentionally runs benchmarks *without*
+`--native` to keep numbers reproducible across runner generations. The
+tables below were produced on a local M2. CI numbers will differ; treat
+local runs as the canonical reference.
+
+## Environment
+
+```
+Run:       20251226-154121
+OS:        macOS 15.5 arm64 Mach-O
+Arch:      arm64
+CPU:       Apple M2
+Compiler:  Apple clang 17.0.0 (clang-1700.0.13.5)
+Build:     -O3, OpenMP on/off, -march=native on/off
+```
+
+Full per-run metadata is pinned in
+[`docs/benchmarks/bench_env.md`](docs/benchmarks/bench_env.md).
+
+## Headline results
+
+### Matrix ops (ns/op, lower is better)
+
+| Case            | baseline  | native    | openmp+native |
+| --------------- | --------- | --------- | ------------- |
+| dot 32          | 6,165     | 6,229     | 6,287         |
+| dot 64          | 65,252    | 57,222    | 89,130        |
+| dot 128         | 575,281   | 587,767   | **374,400**   |
+| dot 256         | 4,835,360 | 4,759,132 | **1,379,835** |
+| transpose 128   | 5,441     | 5,292     | 23,662        |
+| transpose 256   | 23,098    | 22,104    | 31,108        |
+| transpose 512   | 198,735   | 178,676   | **87,914**    |
+| transpose 1024  | 978,383   | 861,078   | **502,426**   |
+| axpy 128        | 3,486     | 3,477     | 23,917        |
+| axpy 256        | 13,886    | 13,896    | 26,335        |
+| axpy 512        | 55,848    | 55,441    | **35,846**    |
+| axpy 1024       | 230,626   | 229,230   | **114,910**   |
+
+### Training and inference throughput (img/s, higher is better)
+
+| Case       | baseline | native  | openmp+native |
+| ---------- | -------- | ------- | ------------- |
+| learn step | 48,755   | 49,399  | 48,636        |
+| classify   | **81,628** | 80,712 | 69,994      |
+
+## Analysis
+
+**OpenMP is a scale story.** At N=32–128 the parallel variants are slower
+than scalar, sometimes by 3–7×. Thread wake-up, fork-join bookkeeping, and
+false-sharing around the accumulator dominate the arithmetic. Past the
+crossover — 128 for `dot`, 512 for `axpy`, 128–512 for `transpose` — the
+openmp+native variant pulls ahead and stays ahead. At dot 256 the parallel
+version is **3.5× faster** than baseline. The `learn()` and `classify()`
+workloads sit in the slow regime by design (784 × 100 × 10 weights), which
+is why the scalar `classify` is actually the fastest number in the final
+table — OpenMP overhead is pure loss at that scale.
+
+**`-march=native` alone barely moves the needle.** Comparing baseline to
+native, the uplift is typically single-digit percent — the hand-written
+intrinsic kernels already dispatch to the widest SIMD the target supports
+at runtime, so giving the autovectorizer more ISA doesn't help it catch up.
+Where `native` does help is in the *non*-kernel code (bounds checks,
+serialization glue), which matters for the end-to-end `learn`/`classify`
+numbers more than for isolated ops.
+
+**The kernels are the bottleneck we chose.** The decision to hand-roll
+AVX-512/AVX2/NEON instead of linking OpenBLAS or Eigen is documented in
+[`docs/adr/0001-hand-rolled-simd-over-bundled-blas.md`](docs/adr/0001-hand-rolled-simd-over-bundled-blas.md).
+OpenBLAS would likely win on large `dot` by another 2–3×; we trade that
+for reproducibility, binary size, and the ability to read every
+optimization in `src/`.
+
+### Scaling charts
+
+<p align="center">
+  <img src="docs/benchmarks/charts/dot-light.svg#gh-light-mode-only" width="760"
+       alt="Dot scaling">
+  <img src="docs/benchmarks/charts/dot-dark.svg#gh-dark-mode-only" width="760"
+       alt="Dot scaling">
+</p>
+
+<p align="center">
+  <img src="docs/benchmarks/charts/transpose-light.svg#gh-light-mode-only"
+       width="760" alt="Transpose scaling">
+  <img src="docs/benchmarks/charts/transpose-dark.svg#gh-dark-mode-only"
+       width="760" alt="Transpose scaling">
+</p>
+
+<p align="center">
+  <img src="docs/benchmarks/charts/axpy-light.svg#gh-light-mode-only" width="760"
+       alt="Axpy scaling">
+  <img src="docs/benchmarks/charts/axpy-dark.svg#gh-dark-mode-only" width="760"
+       alt="Axpy scaling">
+</p>
+
+<p align="center">
+  <img src="docs/benchmarks/charts/throughput-compare-light.svg#gh-light-mode-only"
+       width="760" alt="Throughput comparison">
+  <img src="docs/benchmarks/charts/throughput-compare-dark.svg#gh-dark-mode-only"
+       width="760" alt="Throughput comparison">
+</p>
+
+## Continuous benchmarking
+
+Committed numbers drift. Phase 5 of the roadmap wires
+[CodSpeed](https://codspeed.io/) into CI so every PR reports per-case
+performance deltas against `main`, with a fail-the-build threshold for
+regressions larger than a stated envelope. Until that lands, we treat
+local M2 numbers as the source of truth and rely on reviewers noticing
+unexplained movement in the summary CSV during PR review.
+
+## Raw runs
+
+Committed JSON lives under [`docs/benchmarks/runs/`](docs/benchmarks/runs/):
+
+- `bench-20251226-154121-baseline.json`
+- `bench-20251226-154121-native.json`
+- `bench-20251226-154121-openmp-native.json`
+
+Aggregated summary: [`docs/benchmarks/bench_summary.csv`](docs/benchmarks/bench_summary.csv).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,23 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 ## [Unreleased]
 
 ### Added
-- Track-branch workflow on GitHub with `hygiene`, `frontend`, `backend`, `optimization` long-running branches; feature PRs target tracks, major merges target `main`.
-- Community health files: `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `.github/CODEOWNERS`, `.editorconfig`.
-- `.github/ISSUE_TEMPLATE/` YAML forms (bug_report, feature_request, performance_regression, rfc, config).
-- `.github/pull_request_template.md`.
-- GitHub Actions workflows: CodeQL (C++ + JS/TS), gitleaks secret scan, commitlint enforcement, Dependabot for npm + github-actions.
-- Web side: Motion v12, Tailwind v4 with OKLCH tokens, Geist fonts, `three` + `@react-three/fiber` + `@react-three/drei` with vendor chunk split, `cn` util, `VITE_API_BASE_URL` env support, `web/vercel.json` SPA rewrite.
-- Theme module with View Transitions API crossfade.
-- husky v9 + commitlint + lint-staged + prettier enforcement on commits.
+- **Phase 0 — repo hygiene.** Track-branch workflow on GitHub with `hygiene`, `frontend`, `backend`, `optimization` long-running branches; feature PRs target tracks, major merges target `main`.
+- **Phase 0 — community health.** `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `.github/CODEOWNERS`, `.editorconfig`.
+- **Phase 0 — templates.** `.github/ISSUE_TEMPLATE/` YAML forms (bug_report, feature_request, performance_regression, rfc, config) and `.github/pull_request_template.md`.
+- **Phase 0 — supply chain.** GitHub Actions workflows for CodeQL (C++ + JS/TS), gitleaks secret scan, commitlint enforcement, Dependabot for npm + github-actions.
+- **Phase 0 — commit discipline.** husky v9 + commitlint + lint-staged + prettier enforcement on commits.
+- **Phase 1 — frontend foundations.** Motion v12, Tailwind v4 with OKLCH tokens, Geist fonts, `three` + `@react-three/fiber` + `@react-three/drei` with vendor chunk split, `cn` util, `VITE_API_BASE_URL` env support, `web/vercel.json` SPA rewrite.
+- **Phase 1 — theme.** View Transitions API crossfade for dark/light toggle.
+- **Phase 2 — backend activations.** `/predict` now returns `hidden_activations` + `input_grad` alongside the softmax distribution (see `apps/server.cpp`).
+- **Phase 2 — 3D architecture hero.** Revolvable, scroll-linked `three`/`drei` scene rendering the 784 → 100 → 10 network live.
+- **Phase 2 — canvas rewrite.** perfect-freehand SVG canvas with pressure support and undo/redo.
+- **Phase 2 — real activation viz.** Saliency + heatmap + softmax components wired to the new `/predict` payload.
+- **Phase 2 — paper-shaders hero backdrop.** Sticky-parallax pipeline for the landing surface.
+- **Docs.** README rewritten for current project state; `BENCHMARKS.md` extracted with methodology + analysis; `docs/adr/` seeded with ADR-0001 (hand-rolled SIMD), ADR-0002 (two-layer MLP), ADR-0003 (split server + SPA).
 
 ### Changed
 - `web/src/api/predict.ts` API base is now env-driven (`VITE_API_BASE_URL`) with `http://localhost:8080` fallback for dev.
+- `web/src/App.tsx` wires the Phase 2 scaffolds (3D hero, canvas, activations) into the app shell.
 
 ## [1.0.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -7,29 +7,52 @@
 
 ---
 
+Hand-rolled C++ neural network that classifies MNIST digits at ~97% accuracy,
+with revolvable 3D architecture visualization and real activation heatmaps that
+run in your browser.
+
 [![ci][ci-badge]][ci-url]
 [![license][license-badge]][license-url]
-[![c++][cpp-badge]][cpp-url]
-[![react][react-badge]][react-url]
-[![typescript][ts-badge]][ts-url]
+[![release][release-badge]][release-url]
+[![try it live][live-badge]][live-url]
+[![openssf scorecard][scorecard-badge]][scorecard-url]
 
-High-performance C++ neural network for MNIST digit recognition with
-SIMD kernels, OpenMP, and reproducible benchmarks. Includes an interactive
-React web app for drawing and classifying digits in real-time.
+## Try it live
 
-## Highlights
+[**fast-mnist-nn-yadava5.vercel.app**][live-url] — draw a digit, see the
+prediction, rotate the network.
 
-- **Interactive Web UI** with live prediction as you draw.
-- Animated neural network visualization showing activations.
-- Dark/light theme toggle with system preference detection.
-- SIMD-accelerated matrix ops (AVX2/AVX-512/NEON) with aligned storage.
-- OpenMP-aware hot paths for dot, transpose, and axpy.
-- P2 PGM parser with in-memory + on-disk cache for repeat runs.
-- CLI training + evaluation pipeline with configurable epochs.
-- Catch2 tests wired to CTest.
-- Google Benchmark suite with published results + charts.
-- Doxygen docs target and clang-format config.
-- CI on Linux/macOS/Windows via GitHub Actions.
+> Hosted demo is a Vercel preview; the `/predict` endpoint falls back to an
+> in-browser WASM build if the C++ server is cold.
+
+## 30-second demo
+
+<!-- demo video is recorded via charm VHS once the hosted demo stabilises -->
+<video src="docs/branding/demo.mp4" width="760" autoplay muted loop playsinline>
+  Hand-drawn "7" classified in real time, with activations flowing through
+  the 784 → 100 → 10 network as the camera revolves around the 3D model.
+</video>
+
+## What it is
+
+A C++17 core library that implements a two-layer multilayer perceptron
+(784 → 100 → 10) from the ground up. Matrix primitives — `dot`, `transpose`,
+`axpy` — are hand-written with AVX-512, AVX2, and NEON intrinsics, with a
+scalar fallback and OpenMP parallelism above empirically-tuned element-count
+thresholds. After ~30 epochs on MNIST the network reaches ~97% test accuracy.
+
+The library ships as three deployables. A CLI (`fast_mnist_cli`) trains and
+evaluates from the terminal. An HTTP server (`fast_mnist_server`, built on
+cpp-httplib + nlohmann/json) exposes `/health` and `/predict`. An Emscripten
+build compiles the same core to WebAssembly with `-msimd128`, so the web app
+has an offline fallback when no server is available.
+
+The frontend is a Vite-bundled React 19 + TypeScript SPA. It uses Motion v12
+for transitions, Tailwind v4 with OKLCH tokens for the design system, and
+`three` + `@react-three/fiber` + `@react-three/drei` for a revolvable 3D
+architecture view. Drawing uses perfect-freehand over an SVG canvas. The
+activation heatmap is real, not decorative — it reads `hidden_activations`
+and `input_grad` from the `/predict` response.
 
 ## Quickstart
 
@@ -37,90 +60,26 @@ React web app for drawing and classifying digits in real-time.
 python3 tools/run.py
 ```
 
-This downloads MNIST, builds the project, and runs a training pass.
-Use `python3 tools/run.py --help` for flags.
+Downloads MNIST, configures a Release build, compiles the C++ core, and runs
+a training pass. `python3 tools/run.py --help` for flags.
 
 ## Benchmarks
 
-Run files:
-- `docs/benchmarks/runs/bench-20251226-154121-baseline.json`
-- `docs/benchmarks/runs/bench-20251226-154121-native.json`
-- `docs/benchmarks/runs/bench-20251226-154121-openmp-native.json`
+Full methodology, reproduction command, and charts live in
+[`BENCHMARKS.md`](BENCHMARKS.md). Teaser, Apple M2 / Apple clang 17 / Release:
 
-Configs:
-- baseline: OpenMP off, native off
-- native: OpenMP off, native on
-- openmp+native: OpenMP on, native on
+| Case           | baseline  | native   | openmp+native |
+| -------------- | --------- | -------- | ------------- |
+| dot 256        | 4,835,360 | 4,759,132 | **1,379,835** |
+| transpose 1024 | 978,383   | 861,078   | **502,426**   |
+| axpy 1024      | 230,626   | 229,230   | **114,910**   |
+| classify       | **81,628 img/s** | 80,712 img/s | 69,994 img/s |
 
-Environment:
-- Apple M2, macOS 15.5
-- Apple clang 17.0.0
-- Release (`-O3`, OpenMP on/off, `-march=native` on/off)
+Matrix ops in ns/op (lower is better); classify in images/second (higher is
+better). OpenMP pays off at 128+ for dot, 512+ for axpy, and hurts on small
+sizes — see `BENCHMARKS.md` for the full story and scaling charts.
 
-Matrix ops (ns/op, lower is better):
-
-| Case | baseline | native | openmp+native |
-| --- | --- | --- | --- |
-| dot 32 | `6165` | `6229` | `6287` |
-| dot 64 | `65252` | `57222` | `89130` |
-| dot 128 | `575281` | `587767` | `374400` |
-| dot 256 | `4835360` | `4759132` | `1379835` |
-| transpose 128 | `5441` | `5292` | `23662` |
-| transpose 256 | `23098` | `22104` | `31108` |
-| transpose 512 | `198735` | `178676` | `87914` |
-| transpose 1024 | `978383` | `861078` | `502426` |
-| axpy 128 | `3486` | `3477` | `23917` |
-| axpy 256 | `13886` | `13896` | `26335` |
-| axpy 512 | `55848` | `55441` | `35846` |
-| axpy 1024 | `230626` | `229230` | `114910` |
-
-Training/inference throughput (img/s, higher is better):
-
-| Case | baseline | native | openmp+native |
-| --- | --- | --- | --- |
-| learn step | `48755` | `49399` | `48636` |
-| classify | `81628` | `80712` | `69994` |
-
-OpenMP overhead shows up on smaller sizes; the line charts illustrate where
-parallelism starts to pay off.
-
-<p align="center">
-  <img src="docs/benchmarks/charts/dot-light.svg#gh-light-mode-only" width="760"
-       alt="Dot scaling">
-  <img src="docs/benchmarks/charts/dot-dark.svg#gh-dark-mode-only" width="760"
-       alt="Dot scaling">
-</p>
-
-<p align="center">
-  <img src="docs/benchmarks/charts/transpose-light.svg#gh-light-mode-only"
-       width="760" alt="Transpose scaling">
-  <img src="docs/benchmarks/charts/transpose-dark.svg#gh-dark-mode-only"
-       width="760" alt="Transpose scaling">
-</p>
-
-<p align="center">
-  <img src="docs/benchmarks/charts/axpy-light.svg#gh-light-mode-only" width="760"
-       alt="Axpy scaling">
-  <img src="docs/benchmarks/charts/axpy-dark.svg#gh-dark-mode-only" width="760"
-       alt="Axpy scaling">
-</p>
-
-<p align="center">
-  <img src="docs/benchmarks/charts/throughput-compare-light.svg#gh-light-mode-only"
-       width="760" alt="Throughput comparison">
-  <img src="docs/benchmarks/charts/throughput-compare-dark.svg#gh-dark-mode-only"
-       width="760" alt="Throughput comparison">
-</p>
-
-See `docs/benchmarks/benchmarks.md` for methodology and scripts.
-
-### Run Benchmarks
-
-```sh
-python3 tools/run_benchmarks.py --openmp --native
-```
-
-## Build and Test
+## Build from source
 
 ```sh
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
@@ -128,88 +87,128 @@ cmake --build build
 ctest --test-dir build
 ```
 
-macOS quickstart:
+macOS one-liner:
 
 ```sh
 ./tools/bootstrap_macos.sh
 ```
 
-## Run
+The build is warning-clean on GCC, Clang, and MSVC. Catch2 tests live under
+`tests/` and run via CTest. `cmake -DFAST_MNIST_ENABLE_DOXYGEN=ON` adds a
+`docs` target.
+
+## Run the CLI
 
 ```sh
 ./build/fast_mnist_cli data 5000 10 TrainingSetList.txt TestingSetList.txt
 ```
 
-## Web Frontend
+Arguments: data directory, training set size, epoch count, training list,
+test list. `fast_mnist_trainer` dumps the resulting `model.weights` to disk.
 
-The project includes an interactive React + TypeScript web app for drawing
-digits and getting real-time predictions.
-
-### Features
-
-- **Live Prediction**: Predictions update as you draw (300ms debounce).
-- **Neural Network Visualization**: Animated particles show activations
-  flowing through the 784 → 100 → 10 network.
-- **Dark/Light Theme**: Toggle with system preference detection and
-  localStorage persistence.
-- **Responsive Design**: Works on desktop and mobile.
-
-### Run the Web App
-
-1. Start the C++ API server:
-   ```sh
-   ./build/fast_mnist_server 8080 model.weights
-   ```
-
-2. In another terminal, start the frontend:
-   ```sh
-   cd web
-   npm install
-   npm run dev
-   ```
-
-3. Open http://localhost:5173 in your browser.
-
-### API Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/health` | Health check |
-| POST | `/predict` | Classify digit (accepts `{"pixels": [784 floats]}`) |
-
-## Formatting
+## Run the HTTP server
 
 ```sh
-clang-format -i src/*.cpp include/fast_mnist/*.h apps/*.cpp
+./build/fast_mnist_server 8080 model.weights
 ```
 
-## Documentation
+Exposes:
+
+| Method | Endpoint   | Description                                             |
+| ------ | ---------- | ------------------------------------------------------- |
+| GET    | `/health`  | Liveness probe                                          |
+| POST   | `/predict` | Classify a digit — `{ "pixels": [784 floats in 0..1] }` |
+
+The server returns the predicted label, full softmax distribution, hidden
+activations, and the input-gradient saliency map the frontend uses for
+heatmaps.
+
+## Web app
 
 ```sh
-cmake -S . -B build -DFAST_MNIST_ENABLE_DOXYGEN=ON
-cmake --build build --target docs
+cd web
+npm install
+npm run dev
 ```
 
-## Data
+Opens on `localhost:5173` and talks to `VITE_API_BASE_URL`
+(defaults to `http://localhost:8080`). See [`web/README.md`](web/README.md)
+for Vercel deployment notes.
 
-```sh
-python3 tools/prepare_mnist.py --output data --list-dir .
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  C++17 core      Matrix · NeuralNet · SIMD kernels (AVX-512/   │
+│                  AVX2/NEON) · OpenMP · Xavier init · SGD       │
+└────────────────────────────────────────────────────────────────┘
+         │                │                     │
+         ▼                ▼                     ▼
+   fast_mnist_cli   fast_mnist_server     wasm (emscripten,
+   (train/eval)     (cpp-httplib +        -msimd128)
+                    nlohmann/json)             │
+                         │                     │
+                         └──────────┬──────────┘
+                                    ▼
+                      React 19 + Vite + Motion v12 SPA
+                      · perfect-freehand SVG canvas
+                      · r3f + drei 3D viz
+                      · Tailwind v4 OKLCH tokens
 ```
 
-The script auto-installs `tqdm` for progress bars; pass
-`--no-auto-install` to skip that step.
+## Philosophy
+
+**Goals**
+
+- Transparent: every kernel, every parallel threshold, every serialization
+  byte is readable from `src/` in one sitting.
+- Reproducible: Release builds are bit-stable, CI pins compilers, and
+  benchmark JSON is committed.
+- Performant at small scale: a 784 × 100 × 10 network should classify a digit
+  in microseconds, not milliseconds.
+
+**Non-goals**
+
+- Training large models. The net fits in L1. That's the point.
+- Distributed serving. One process, one model, no coordinator.
+- A reusable ML library. `NeuralNet` is hardcoded to two layers by design —
+  see [`docs/adr/0002-two-layer-mlp-not-generic-graph.md`](docs/adr/0002-two-layer-mlp-not-generic-graph.md).
+
+Design trade-offs are documented in [`docs/adr/`](docs/adr/).
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the branching model, commit
+convention, and PR template. Security issues: [`SECURITY.md`](SECURITY.md).
+Code of conduct: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Acknowledgments
+
+- Michael Nielsen, *Neural Networks and Deep Learning* — the reference
+  implementation and pedagogy behind the two-layer MLP.
+- [Shree Chaturvedi](https://github.com/shreebatsa) — frontend contributions
+  and review.
+- [cpp-httplib](https://github.com/yhirose/cpp-httplib),
+  [nlohmann/json](https://github.com/nlohmann/json),
+  [Catch2](https://github.com/catchorg/Catch2),
+  [Google Benchmark](https://github.com/google/benchmark),
+  [perfect-freehand](https://github.com/steveruizok/perfect-freehand),
+  [react-three-fiber](https://github.com/pmndrs/react-three-fiber),
+  [drei](https://github.com/pmndrs/drei),
+  [Motion](https://motion.dev/),
+  [Tailwind CSS](https://tailwindcss.com/).
 
 ## License
 
-MIT -- see `LICENSE`.
+MIT — see [`LICENSE`](LICENSE).
 
 [ci-badge]: https://github.com/yadava5/fast-mnist-nn/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/yadava5/fast-mnist-nn/actions/workflows/ci.yml
 [license-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [license-url]: LICENSE
-[cpp-badge]: https://img.shields.io/badge/C%2B%2B-17-blue.svg
-[cpp-url]: https://isocpp.org/
-[react-badge]: https://img.shields.io/badge/React-19-61DAFB.svg?logo=react
-[react-url]: https://react.dev/
-[ts-badge]: https://img.shields.io/badge/TypeScript-5-3178C6.svg?logo=typescript
-[ts-url]: https://www.typescriptlang.org/
+[release-badge]: https://img.shields.io/github/v/release/yadava5/fast-mnist-nn?sort=semver
+[release-url]: https://github.com/yadava5/fast-mnist-nn/releases
+[live-badge]: https://img.shields.io/badge/try%20it-live-brightgreen
+[live-url]: https://fast-mnist-nn-yadava5.vercel.app
+[scorecard-badge]: https://api.securityscorecards.dev/projects/github.com/yadava5/fast-mnist-nn/badge
+[scorecard-url]: https://securityscorecards.dev/viewer/?uri=github.com/yadava5/fast-mnist-nn

--- a/docs/adr/0001-hand-rolled-simd-over-bundled-blas.md
+++ b/docs/adr/0001-hand-rolled-simd-over-bundled-blas.md
@@ -1,0 +1,91 @@
+# ADR-0001: Hand-rolled SIMD kernels instead of Eigen or OpenBLAS
+
+- **Status:** Accepted
+- **Date:** 2025-12-26
+- **Deciders:** Ayush Yadav
+- **Consulted:** —
+- **Informed:** contributors
+
+## Context and problem statement
+
+A neural-network library needs fast matrix primitives — `dot`, `transpose`,
+`axpy`. The conventional answer is to link a well-tuned BLAS
+(OpenBLAS, BLIS, Apple Accelerate) or include a header-only linear algebra
+library like Eigen. Those are faster than anything we will write in a
+weekend, and they are production-grade.
+
+`fast-mnist-nn` has different priorities: it is a showcase project where
+every performance claim needs to be auditable from the `src/` tree in one
+reading, it ships as a self-contained binary, and it targets three
+operating systems plus WebAssembly. How should the core matrix kernels be
+implemented?
+
+## Decision drivers
+
+- Readability of the hot path — reviewers should be able to see *why* a
+  number is what it is.
+- Minimal external dependencies — shorter build times, smaller binaries,
+  portable cross-compiles (including Emscripten).
+- Reproducible numbers across machines and revisions.
+- Educational value: the project exists partly to demonstrate how SIMD and
+  OpenMP actually work.
+- Performance "good enough" for a 784 × 100 × 10 network, not
+  GEMM-on-GPU territory.
+
+## Considered options
+
+1. **Hand-write AVX-512, AVX2, and NEON intrinsics with a scalar fallback.**
+2. **Link OpenBLAS** for GEMM/AXPY and call out via a thin wrapper.
+3. **Vendor Eigen** as a header-only dependency.
+4. **Use a SIMD-wrapping library** like Google Highway or xsimd.
+
+## Decision
+
+Option 1. `Matrix::dot`, `Matrix::transpose`, and `Matrix::axpy` are
+implemented with explicit AVX-512 / AVX2 / NEON intrinsics, guarded by
+`__AVX512F__` / `__AVX2__` / `__ARM_NEON` feature macros, with a scalar
+fallback. OpenMP parallelism sits above the kernels, gated by
+empirically-tuned element-count thresholds.
+
+## Consequences
+
+**Good**
+
+- The hot path is 200 lines the reader can audit. Every optimization —
+  tiling, FMA fusion, aligned load, bias-add fold — is visible.
+- No FFI, no platform-specific dynamic-library search, no ABI mismatches.
+  The Emscripten build "just works" by falling through to the scalar path
+  with `-msimd128`.
+- Release-build numbers are bit-stable across runs on the same machine,
+  which makes the benchmark CSV meaningful.
+- Binary size stays small (< 1 MiB for the CLI).
+
+**Bad**
+
+- OpenBLAS's hand-tuned GEMM beats our blocked kernel by roughly 2–3× on
+  large matrices. For a 784 × 100 × 10 network this is invisible; for
+  anything larger it would matter.
+- We own one implementation per ISA. Adding RISC-V Vector or SVE means
+  writing another kernel, not flipping a flag.
+- We do not get OpenBLAS's threading, packing, or cache-blocking
+  heuristics for free.
+
+## Alternatives considered and why they were rejected
+
+- **OpenBLAS.** Best raw performance, but introduces a heavyweight native
+  dependency that complicates Windows builds, cross-compiles, and
+  Emscripten entirely. Defeats the "every performance claim is in `src/`"
+  goal.
+- **Eigen.** No link-time dependency, but the header surface is enormous,
+  compile times balloon, and the generated assembly is hard to explain to
+  a reader — the opposite of what this project is selling.
+- **Highway / xsimd.** Technically the "right" modern answer for new
+  projects. Rejected because abstracting over SIMD hides the kernels we
+  specifically want to showcase; the wrapper would be more code than the
+  kernels themselves.
+
+## Validation
+
+The `benchmarks/` suite documents the actual performance envelope and the
+published numbers in [`BENCHMARKS.md`](../../BENCHMARKS.md) make the
+"within 2–3× of OpenBLAS on the sizes we care about" claim inspectable.

--- a/docs/adr/0002-two-layer-mlp-not-generic-graph.md
+++ b/docs/adr/0002-two-layer-mlp-not-generic-graph.md
@@ -1,0 +1,99 @@
+# ADR-0002: Hardcoded 2-layer MLP instead of a generic computation graph
+
+- **Status:** Accepted
+- **Date:** 2025-12-26
+- **Deciders:** Ayush Yadav
+- **Consulted:** —
+- **Informed:** contributors
+
+## Context and problem statement
+
+MNIST classifiers are conventionally written against a generic computation
+graph — a list of layers, each exposing `forward` and `backward`, wired up
+dynamically. PyTorch, TensorFlow, tinygrad, and ggml all do this. A
+generic representation makes it trivial to swap 2-layer MLP for a 5-layer
+MLP or a small CNN.
+
+`fast-mnist-nn` only ever needs one architecture: a 784 → 100 → 10
+fully-connected network with sigmoid activations. Given that, should
+`NeuralNet` still carry the generic-graph machinery?
+
+## Decision drivers
+
+- Inference hot-path latency (the whole project is sold on microsecond
+  classify times).
+- Readability of the core class — is a new reader able to trace a single
+  prediction end-to-end?
+- Weight file format simplicity — the text format is part of the
+  reproducibility contract.
+- Future-proofing against adding a convolutional or deeper variant.
+
+## Considered options
+
+1. **Hardcode exactly 2 layers** (an input layer with hidden-sized output,
+   and an output layer with 10 outputs). Static per-thread hidden buffer
+   inside `classify()`.
+2. **Store layers as a `std::vector<Layer>`** and iterate in both
+   `classify()` and `learn()`.
+3. **Use a computation-graph representation** with nodes, edges, and a
+   scheduler.
+
+## Decision
+
+Option 1 for the inference path, with an asymmetric compromise on the
+training path.
+
+- `NeuralNet::classify()` assumes exactly two layers. The hidden
+  activations live in a fixed-size static buffer sized for the 100-unit
+  hidden layer. No dispatch, no allocation, no indirection per layer.
+- `NeuralNet::learn()` IS written generically over `layers.size()` — the
+  layer-by-layer backward pass benefits from the loop structure and the
+  inner-loop cost dominates any overhead.
+
+The asymmetry is deliberate: inference runs hot on the web server, training
+runs cold and offline.
+
+## Consequences
+
+**Good**
+
+- The `classify()` inner loop fits comfortably in L1 and has no
+  per-layer dispatch overhead. This is what makes 81k img/s possible on
+  commodity hardware.
+- The weight file is two matrices, two bias vectors, and two header
+  lines — human-readable, diffable, easy to port.
+- The intent of the code matches the intent of the project: this is a
+  two-layer MLP, and it advertises itself as one.
+
+**Bad**
+
+- Adding a third layer, let alone a convolution, is a rewrite, not an
+  extension. Any future architecture work means revisiting `NeuralNet`
+  wholesale.
+- Sharp edge: if someone trains a non-2-layer model offline and loads it
+  into `classify()`, the static hidden buffer is the wrong size. This is
+  asserted in the weight-file header check, but it is a latent foot-gun.
+- The asymmetry between `classify()` (hardcoded) and `learn()` (generic)
+  surprises readers. The asymmetry is documented in the header; it is
+  still asymmetric.
+
+## Alternatives considered and why they were rejected
+
+- **Generic layer-list iteration inside `classify()`.** Loses the
+  static-buffer performance win, which is the whole point. Benchmarked
+  during prototyping and came in ~15% slower on M2.
+- **Full graph representation.** Too much machinery for a showcase — we
+  would be writing a miniature framework, not a neural net. Rejected as
+  over-engineering relative to the project's scope (see
+  [ADR-0001](0001-hand-rolled-simd-over-bundled-blas.md) for the parallel
+  reasoning on kernels).
+- **Compile-time templates over layer count.** Would preserve performance
+  while allowing 3-, 4-, 5-layer variants. Rejected because it inflates
+  compile times, bloats the binary across template instantiations, and
+  provides no benefit for the sole architecture we ship.
+
+## Validation
+
+Inference throughput in [`BENCHMARKS.md`](../../BENCHMARKS.md) (81,628
+img/s classify on baseline) is the load-bearing evidence. The assertion
+in the weight-file header check guards the sharp-edge described above.

--- a/docs/adr/0003-separate-server-and-frontend-not-monorepo-ssr.md
+++ b/docs/adr/0003-separate-server-and-frontend-not-monorepo-ssr.md
@@ -1,0 +1,113 @@
+# ADR-0003: Separate C++ server + React SPA, not a monorepo Next.js SSR app
+
+- **Status:** Accepted
+- **Date:** 2026-04-22
+- **Deciders:** Ayush Yadav
+- **Consulted:** Shree Chaturvedi
+- **Informed:** contributors
+
+## Context and problem statement
+
+The web experience needs (a) a way to run inference against the trained
+C++ network and (b) a frontend that draws digits, visualizes
+activations, and renders a revolvable 3D architecture view. There are
+several plausible shapes for that combination:
+
+- A Next.js monorepo with the inference logic inlined via N-API bindings,
+  rendered server-side.
+- A Next.js app that calls out to a separately-deployed inference
+  service.
+- A static SPA that calls a standalone HTTP inference server.
+- A static SPA that runs inference locally in the browser via WebAssembly.
+
+The project already has a mature C++17 core. The question is how to
+expose it to the web.
+
+## Decision drivers
+
+- Deploy independence — the frontend should ship on one cadence, the
+  inference on another.
+- Reproducibility of the inference pipeline — the hot path should stay
+  C++ with the exact same binary we benchmark.
+- Single-origin deploy cost — a hobby-scale hosted demo must be free or
+  near-free to keep running.
+- Offline / no-server story — the demo should degrade gracefully when
+  no backend is reachable.
+- Platform risk — we want to avoid nodes in the architecture that depend
+  on a single fragile ecosystem (e.g. N-API).
+
+## Considered options
+
+1. **Two deployables:** a C++ HTTP server (`fast_mnist_server`, using
+   cpp-httplib + nlohmann/json) and a Vite-built React SPA that calls
+   it over `VITE_API_BASE_URL`. Plus a WASM fallback compiled from the
+   same C++ core.
+2. **Next.js monorepo with N-API bindings** to call into the C++ core
+   from Node, rendered SSR.
+3. **C++ web framework** (Drogon, Crow) serving templated HTML directly.
+4. **SPA with inference only in WASM**, no server.
+
+## Decision
+
+Option 1. Three artefacts, one source of truth:
+
+- `fast_mnist_server` — the C++ inference binary. Same kernels, same
+  serialization format. Deployed separately (Fly.io / Railway / Modal /
+  any VPS).
+- `web/` — a Vite-built React 19 SPA. Statically deployed on Vercel.
+- WASM build — compiled from the same C++ core via Emscripten with
+  `-msimd128`. Used as an offline fallback when `VITE_API_BASE_URL` is
+  unreachable.
+
+## Consequences
+
+**Good**
+
+- Single-purpose deployables. The server handles inference and nothing
+  else; the frontend handles UI and nothing else. Each ships and scales
+  on its own cadence.
+- The C++ kernels stay a library and are consumed identically by three
+  targets (CLI, HTTP, WASM). One source of truth for performance claims.
+- Vercel hosts the SPA on its free tier. The inference server can go on
+  any VPS, free-tier Fly.io, Modal, or Railway — or be omitted entirely
+  in favour of the WASM fallback.
+- Graceful degradation: when the server is cold or the user is offline,
+  the same UI keeps working, just slower.
+- No Node-in-the-hot-path. Benchmarks remain meaningful because the
+  inference path is identical to the CLI path.
+
+**Bad**
+
+- Two deploy pipelines, two failure domains, two sets of logs to watch.
+- CORS and environment-variable management across dev / preview /
+  production environments. `VITE_API_BASE_URL` lives in three places
+  (local `.env`, Vercel project config, hosted-demo overrides).
+- Two separate version headers — the SPA could be talking to an older
+  server. We mitigate with a `/health` endpoint that reports a build
+  hash, but it is operational overhead.
+
+## Alternatives considered and why they were rejected
+
+- **Next.js monorepo with N-API bindings.** Would be one deploy, but
+  N-API binaries are platform-specific, binding libraries are
+  mid-maintained, and the resulting cross-compile story across Linux /
+  macOS / Windows is a long tail of toolchain work. Rejected for
+  fragility.
+- **Next.js frontend + separate inference service.** Plausible; adds
+  server-rendering machinery we do not need. The SPA rendering time is
+  not a visible bottleneck; SSR adds complexity for no user-facing win.
+- **C++ web framework serving templated HTML.** Good for a tech demo,
+  bad for the interactive 3D visualization we want — Motion / r3f /
+  Tailwind need a proper JS build. Also precludes Vercel-style hosting.
+- **Pure WASM, no server.** Tempting, and we keep it as the fallback
+  path. Rejected as the *primary* path because (a) the native server
+  path is faster by a factor we want to showcase in benchmarks, and
+  (b) the WASM binary adds 1–2 MiB of first-load payload the SPA should
+  not pay up front.
+
+## Validation
+
+The SPA builds clean on Vercel preview. `fast_mnist_server` runs the
+same Catch2 tests as the CLI. The WASM path is built in CI on every PR;
+`VITE_API_BASE_URL` override is documented in
+[`web/README.md`](../../web/README.md).


### PR DESCRIPTION
## Summary

Public-facing docs pass. README rewritten to reflect Phase 0/1/2 work, benchmark content extracted to a dedicated BENCHMARKS.md, and three retrospective ADRs seeded under docs/adr/.

## Why

- Old README did not reflect shipped work: Motion/Tailwind/r3f frontend rewrite, backend activation payload, perfect-freehand canvas, real saliency heatmaps, WASM fallback path.
- Benchmark tables were crowding the README and hiding everything else the project does; the reproduction story was buried in docs/benchmarks/benchmarks.md and not linked.
- Three load-bearing design decisions (hand-rolled SIMD instead of OpenBLAS, two-layer MLP instead of generic graph, split server+SPA instead of Next.js monorepo) were being re-litigated in every review and needed permanent, citable documents.

## Changes

- `README.md` rewritten, 214 lines. New structure: hero, tagline, 5 badges, Try-it-live, 30-second demo placeholder, what-it-is prose, quickstart, benchmarks teaser, build, CLI/server/web, ASCII architecture diagram, philosophy, contributing, acknowledgments, license.
- `BENCHMARKS.md` created, 161 lines. Methodology, reproduction command, environment pin (Apple M2 / macOS 15.5 / Apple clang 17), headline tables verbatim from old README, prose analysis of the OpenMP-overhead-on-small-sizes story, scaling charts, continuous-benchmarking plan pointing at CodSpeed.
- `docs/adr/0001-hand-rolled-simd-over-bundled-blas.md` — 91 lines, MADR 4.0.
- `docs/adr/0002-two-layer-mlp-not-generic-graph.md` — 99 lines, MADR 4.0.
- `docs/adr/0003-separate-server-and-frontend-not-monorepo-ssr.md` — 113 lines, MADR 4.0.
- `CHANGELOG.md` — phase-tagged Unreleased entries covering Phase 0 hygiene, Phase 1 frontend foundations, Phase 2 backend/viz/canvas work, plus the docs pass itself.

Per-file commits:

1. `docs(readme): rewrite for current project state`
2. `docs(benchmarks): extract BENCHMARKS.md from README`
3. `docs(adr): ADR-0001 hand-rolled SIMD rationale`
4. `docs(adr): ADR-0002 two-layer MLP rationale`
5. `docs(adr): ADR-0003 split server + SPA architecture`
6. `docs(release): update CHANGELOG with Phase 0/1/2 entries`

## Test plan

- [x] `wc -l` on each file within its target envelope (README 214, BENCHMARKS 161, ADRs 91/99/113).
- [x] Every relative link in README and BENCHMARKS and the ADRs resolves on disk (`LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `web/README.md`, `docs/adr/*`, `docs/benchmarks/*`, chart SVGs, runs dir, summary CSV).
- [x] No literal `TODO` in README; "coming soon" prose used where content is pending.
- [x] Commits follow Conventional Commits with WHAT/WHY/INTENT/VALIDATION bodies.
- [ ] GitHub renders the hero SVGs, ASCII diagram, and chart SVGs correctly (verify on PR preview).
- [ ] `markdownlint-cli2` passes on all six files (opportunistic; no CI gate today).

## Breaking changes

None — documentation only.

## Rollback

Revert this PR; the previous README content is preserved in git history at `hygiene^`.

## Follow-ups

- Record the 30-second demo video via charm VHS once the hosted Vercel preview stabilises and drop it at `docs/branding/demo.mp4`.
- Wire CodSpeed into CI (Phase 5) and flip the TODO section in BENCHMARKS.md to document actual continuous-benchmarking behaviour.
- Consider promoting `docs/adr/` into the top-level nav once there are 5+ ADRs.