### PR TITLE
test: sanitizer matrix CI + expanded Catch2 + rapidcheck

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -32,7 +32,12 @@ jobs:
       # Fail the job on the first sanitizer report. Without these the
       # sanitizers only print diagnostics and keep running, which masks
       # failures when ctest's return code comes back 0.
-      ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1
+      #
+      # detect_leaks is intentionally NOT set here: LeakSanitizer is
+      # unsupported on macOS and the runtime aborts at startup if
+      # detect_leaks=1 is passed. The per-step ASAN_OPTIONS block
+      # below appends it only on Linux.
+      ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:strict_string_checks=1:detect_stack_use_after_return=1
       UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_stacktrace=1
       TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:history_size=4
 
@@ -85,4 +90,11 @@ jobs:
         run: cmake --build build-san --target fast_mnist_tests --parallel
 
       - name: Run tests under sanitizer
-        run: ctest --test-dir build-san --output-on-failure
+        run: |
+          # Enable LSan only on Linux; macOS ASan has no LSan runtime
+          # and aborts at startup if detect_leaks=1 is set.
+          if [ "$RUNNER_OS" = "Linux" ] && \
+             [ "${{ matrix.sanitizer }}" != "tsan" ]; then
+            export ASAN_OPTIONS="$ASAN_OPTIONS:detect_leaks=1"
+          fi
+          ctest --test-dir build-san --output-on-failure

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,88 @@
+name: Sanitizers
+
+on:
+  push:
+    branches: [main, optimization]
+  pull_request:
+
+# Kill in-flight sanitizer jobs from the same ref when a new push lands.
+# A full asan+ubsan+tsan sweep takes ~8 min per cell; two concurrent runs
+# for the same PR is pure CI burn.
+concurrency:
+  group: sanitizers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sanitize:
+    name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.sanitizer }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        sanitizer: [asan-ubsan, tsan]
+        compiler: [clang, gcc]
+        exclude:
+          # Apple "gcc" is a clang shim; running the same clang path twice
+          # adds noise without catching new bugs.
+          - os: macos-latest
+            compiler: gcc
+
+    env:
+      # Fail the job on the first sanitizer report. Without these the
+      # sanitizers only print diagnostics and keep running, which masks
+      # failures when ctest's return code comes back 0.
+      ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1
+      UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_stacktrace=1
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:history_size=4
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OpenMP (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
+      - name: Select compiler (Linux + gcc)
+        if: runner.os == 'Linux' && matrix.compiler == 'gcc'
+        run: |
+          echo "CC=gcc" >> "$GITHUB_ENV"
+          echo "CXX=g++" >> "$GITHUB_ENV"
+
+      - name: Select compiler (Linux + clang)
+        if: runner.os == 'Linux' && matrix.compiler == 'clang'
+        run: |
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
+      - name: Select compiler (macOS + clang)
+        if: runner.os == 'macOS' && matrix.compiler == 'clang'
+        run: |
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
+      - name: Configure
+        run: |
+          # OpenMP is disabled under TSan: the TSan runtime and the
+          # OpenMP runtime both install signal handlers and disagree on
+          # thread synchronisation primitives, producing spurious races
+          # that say nothing about our code. ASan+UBSan do cope with
+          # OpenMP, so we leave it on there.
+          if [ "${{ matrix.sanitizer }}" = "tsan" ]; then
+            OMP_FLAG=-DFAST_MNIST_ENABLE_OPENMP=OFF
+          else
+            OMP_FLAG=-DFAST_MNIST_ENABLE_OPENMP=ON
+          fi
+          cmake -S . -B build-san \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_TESTING=ON \
+            -DFAST_MNIST_ENABLE_SANITIZERS=${{ matrix.sanitizer }} \
+            -DFAST_MNIST_ENABLE_NATIVE=OFF \
+            $OMP_FLAG
+
+      - name: Build tests
+        run: cmake --build build-san --target fast_mnist_tests --parallel
+
+      - name: Run tests under sanitizer
+        run: ctest --test-dir build-san --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,14 +149,51 @@ if(BUILD_TESTING)
   )
   FetchContent_MakeAvailable(Catch2)
 
+  # rapidcheck: property-based test fuzzer that plugs into Catch2.
+  # No tagged releases upstream, so we pin to a specific commit SHA.
+  #
+  # RC_ENABLE_CATCH is deliberately left OFF: turning it on pulls in
+  # rapidcheck's vendored Catch2 v2.4.2 under ext/catch, which
+  # collides with the Catch2 v3 FetchContent above ("target Catch2
+  # already exists"). The integration header we actually need lives
+  # in extras/catch and is header-only; we add that directory
+  # manually below once rapidcheck is populated so we get the
+  # `rapidcheck_catch` INTERFACE target without the duplicate
+  # Catch2.
+  set(RC_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+  set(RC_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
+  set(RC_ENABLE_CATCH OFF CACHE BOOL "" FORCE)
+  FetchContent_Declare(
+    rapidcheck
+    GIT_REPOSITORY https://github.com/emil-e/rapidcheck.git
+    GIT_TAG b96a4e626ef4c7348dcd16c500353c2f997a9f3f
+  )
+  FetchContent_MakeAvailable(rapidcheck)
+
+  # Manually register the Catch integration (header-only INTERFACE
+  # target). Skip if for any reason a future rapidcheck SHA already
+  # provides the target -- guards against accidental re-inclusion.
+  if(NOT TARGET rapidcheck_catch)
+    add_subdirectory(
+      "${rapidcheck_SOURCE_DIR}/extras/catch"
+      "${rapidcheck_BINARY_DIR}/extras/catch"
+    )
+  endif()
+
   add_executable(fast_mnist_tests
     tests/test_matrix.cpp
+    tests/test_matrix_properties.cpp
     tests/test_neural_net.cpp
   )
   target_link_libraries(fast_mnist_tests
     PRIVATE
       fast_mnist
       Catch2::Catch2WithMain
+      # rapidcheck_catch is INTERFACE and already transitively links
+      # the rapidcheck static lib, so listing it alone is enough.
+      # Adding rapidcheck a second time triggers a linker warning on
+      # macOS ("ignoring duplicate libraries").
+      rapidcheck_catch
   )
 
   include(Catch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,16 @@ option(FAST_MNIST_ENABLE_NATIVE "Enable -march=native" OFF)
 option(FAST_MNIST_ENABLE_BENCHMARKS "Enable Google Benchmark" OFF)
 option(FAST_MNIST_ENABLE_DOXYGEN "Enable Doxygen docs target" OFF)
 
+# Sanitizer selection. Accepts: OFF, asan, ubsan, asan-ubsan, tsan, msan.
+# Must be a cache STRING (not BOOL) because CMake's `option()` only
+# supports ON/OFF. The flags are applied PUBLIC on the fast_mnist
+# library target so they propagate to every downstream consumer
+# (apps, tests, benchmarks).
+set(FAST_MNIST_ENABLE_SANITIZERS "OFF" CACHE STRING
+    "Enable sanitizers (OFF|asan|ubsan|asan-ubsan|tsan|msan)")
+set_property(CACHE FAST_MNIST_ENABLE_SANITIZERS PROPERTY STRINGS
+    OFF asan ubsan asan-ubsan tsan msan)
+
 add_library(fast_mnist
   src/Matrix.cpp
   src/NeuralNet.cpp
@@ -31,6 +41,48 @@ if(FAST_MNIST_ENABLE_NATIVE)
     message(WARNING "FAST_MNIST_ENABLE_NATIVE is not supported on MSVC")
   else()
     target_compile_options(fast_mnist PRIVATE -march=native)
+  endif()
+endif()
+
+# Sanitizer flag application. PUBLIC so the flags propagate to every
+# target that links fast_mnist -- CLI, trainer, server, tests, and
+# benchmarks. Frame pointers are preserved so symbolicated stack
+# traces are readable, and -O1 is forced to keep inlining shallow
+# enough for useful reports without slowing the build to a crawl.
+if(NOT FAST_MNIST_ENABLE_SANITIZERS STREQUAL "OFF")
+  if(MSVC)
+    message(WARNING "Sanitizers not supported on MSVC; ignoring "
+            "FAST_MNIST_ENABLE_SANITIZERS=${FAST_MNIST_ENABLE_SANITIZERS}")
+  elseif(FAST_MNIST_ENABLE_SANITIZERS STREQUAL "asan-ubsan")
+    target_compile_options(fast_mnist PUBLIC
+      -fsanitize=address,undefined -fno-omit-frame-pointer -O1)
+    target_link_options(fast_mnist PUBLIC
+      -fsanitize=address,undefined)
+  elseif(FAST_MNIST_ENABLE_SANITIZERS STREQUAL "asan")
+    target_compile_options(fast_mnist PUBLIC
+      -fsanitize=address -fno-omit-frame-pointer -O1)
+    target_link_options(fast_mnist PUBLIC -fsanitize=address)
+  elseif(FAST_MNIST_ENABLE_SANITIZERS STREQUAL "ubsan")
+    target_compile_options(fast_mnist PUBLIC
+      -fsanitize=undefined -fno-omit-frame-pointer -O1)
+    target_link_options(fast_mnist PUBLIC -fsanitize=undefined)
+  elseif(FAST_MNIST_ENABLE_SANITIZERS STREQUAL "tsan")
+    target_compile_options(fast_mnist PUBLIC
+      -fsanitize=thread -fno-omit-frame-pointer -O1)
+    target_link_options(fast_mnist PUBLIC -fsanitize=thread)
+  elseif(FAST_MNIST_ENABLE_SANITIZERS STREQUAL "msan")
+    # MSan needs an MSan-instrumented libc++. The CI matrix skips this;
+    # document the manual path instead of wiring it up and failing on
+    # every standard toolchain.
+    message(WARNING
+      "MSan requires an instrumented libc++; skipping automatic setup. "
+      "Build your own libc++ with -fsanitize=memory and pass "
+      "-stdlib=libc++ -L<path-to-libcxx> manually if you need it.")
+  else()
+    message(FATAL_ERROR
+      "Unknown FAST_MNIST_ENABLE_SANITIZERS value: "
+      "'${FAST_MNIST_ENABLE_SANITIZERS}'. "
+      "Expected one of: OFF, asan, ubsan, asan-ubsan, tsan, msan.")
   endif()
 endif()
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Reproducibility harness for the Google Benchmark suite.
+#
+# Configures a Release build with OpenMP + -march=native, builds
+# fast_mnist_benchmarks, and runs it with 10 repetitions per case
+# writing aggregated JSON so the run can be diffed against a baseline
+# (e.g. in a CodSpeed / bench-action workflow or by a human eye).
+#
+# Tries to pin the Linux CPU governor to "performance" before running
+# so benchmark numbers are comparable across machines on the same
+# kernel build. Silently skips that step on macOS / non-privileged
+# shells -- the benchmarks still run, they are just noisier.
+#
+# Usage:
+#   scripts/bench.sh                    # writes bench-<timestamp>.json
+#   scripts/bench.sh out.json           # writes out.json
+set -euo pipefail
+
+OUT="${1:-bench-$(date +%Y%m%d-%H%M%S).json}"
+
+# ----------------------------------------------------------------------
+# Linux-only: best-effort CPU governor pin.
+# ----------------------------------------------------------------------
+if [[ "$(uname)" == "Linux" ]]; then
+  if command -v cpupower >/dev/null 2>&1; then
+    if sudo -n true 2>/dev/null; then
+      sudo cpupower frequency-set -g performance >/dev/null 2>&1 \
+        || echo "warn: could not set CPU governor" >&2
+    else
+      echo "warn: cpupower present but sudo is non-interactive; skipping" >&2
+    fi
+  fi
+fi
+
+# ----------------------------------------------------------------------
+# Configure + build.
+# ----------------------------------------------------------------------
+cmake -S . -B build-bench \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DFAST_MNIST_ENABLE_OPENMP=ON \
+  -DFAST_MNIST_ENABLE_NATIVE=ON \
+  -DFAST_MNIST_ENABLE_BENCHMARKS=ON
+
+cmake --build build-bench --target fast_mnist_benchmarks --parallel
+
+# ----------------------------------------------------------------------
+# Run.
+# ----------------------------------------------------------------------
+# - 10 repetitions cuts noise and makes Welch's t-test downstream
+#   meaningful.
+# - aggregates_only=true collapses the 10 runs into mean/median/stddev
+#   so the JSON stays compact.
+# - json output is the format bench diff tools (googlebench_compare,
+#   codspeed) accept directly.
+./build-bench/fast_mnist_benchmarks \
+  --benchmark_repetitions=10 \
+  --benchmark_report_aggregates_only=true \
+  --benchmark_out_format=json \
+  --benchmark_out="$OUT"
+
+echo "wrote $OUT"

--- a/tests/test_matrix.cpp
+++ b/tests/test_matrix.cpp
@@ -1,32 +1,135 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <cmath>
+#include <cstdint>
+#include <functional>
 #include <sstream>
+#include <utility>
 
 #include "fast_mnist/Matrix.h"
 
-TEST_CASE("Matrix initializes and indexes", "[matrix]") {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+namespace {
+
+// Hand-fill a Matrix with a row-major sequence; useful for the many
+// small predictable fixtures in this file.
+void fillSequential(Matrix& m, double start = 1.0, double step = 1.0) {
+    double v = start;
+    for (std::size_t r = 0; r < m.height(); ++r) {
+        for (std::size_t c = 0; c < m.width(); ++c) {
+            m[r][c] = v;
+            v += step;
+        }
+    }
+}
+
+// Identity matrix constructor -- we use this in several cases and
+// Matrix does not ship a dedicated identity() factory.
+Matrix identity(std::size_t n) {
+    Matrix I(n, n, 0.0);
+    for (std::size_t i = 0; i < n; ++i)
+        I[i][i] = 1.0;
+    return I;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Constructor + basic accessor coverage
+// ---------------------------------------------------------------------------
+TEST_CASE("Matrix initializes and indexes", "[matrix][basic]") {
     Matrix m(2, 3, 0.0);
-    m[0][0] = 1.0;
-    m[0][1] = 2.0;
-    m[0][2] = 3.0;
-    m[1][0] = 4.0;
-    m[1][1] = 5.0;
-    m[1][2] = 6.0;
+    fillSequential(m);
 
     REQUIRE(m.height() == 2);
     REQUIRE(m.width() == 3);
+    REQUIRE(m[0][0] == 1.0);
     REQUIRE(m[1][2] == 6.0);
+    REQUIRE_FALSE(m.empty());
 }
 
-TEST_CASE("Matrix transpose preserves values", "[matrix]") {
+TEST_CASE("Empty matrices are well-behaved", "[matrix][edge]") {
+    SECTION("default-constructed matrix is empty") {
+        Matrix m;
+        REQUIRE(m.empty());
+        REQUIRE(m.height() == 0);
+        REQUIRE(m.width() == 0);
+    }
+
+    SECTION("{0, 0} matrix is empty") {
+        Matrix m(0, 0, 0.0);
+        REQUIRE(m.empty());
+    }
+
+    SECTION("zero-row / zero-col matrices are empty") {
+        Matrix rows0(0, 5, 0.0);
+        Matrix cols0(5, 0, 0.0);
+        REQUIRE(rows0.empty());
+        REQUIRE(cols0.empty());
+    }
+
+    SECTION("size-zero transpose + apply do not crash") {
+        Matrix m;
+        Matrix t = m.transpose();
+        REQUIRE(t.empty());
+
+        Matrix negated = m.apply([](double v) { return -v; });
+        REQUIRE(negated.empty());
+    }
+
+    SECTION("axpy on empty matrix is a no-op") {
+        Matrix m;
+        Matrix x;
+        // Should not crash even when both sides are empty.
+        m.axpy(2.0, x);
+        REQUIRE(m.empty());
+    }
+}
+
+TEST_CASE("Row and column vectors behave correctly", "[matrix][edge]") {
+    SECTION("1xN row vector transpose") {
+        Matrix row(1, 5, 0.0);
+        fillSequential(row);
+
+        Matrix col = row.transpose();
+        REQUIRE(col.height() == 5);
+        REQUIRE(col.width() == 1);
+        for (std::size_t i = 0; i < 5; ++i) {
+            REQUIRE(col[i][0] == Catch::Approx(static_cast<double>(i + 1)));
+        }
+    }
+
+    SECTION("Nx1 column vector dot produces inner-product shape") {
+        // (1x3) . (3x1) -> (1x1) scalar-shaped matrix.
+        Matrix row(1, 3, 0.0);
+        Matrix col(3, 1, 0.0);
+        fillSequential(row);   // [1 2 3]
+        fillSequential(col);   // [1;2;3]
+        Matrix r = row.dot(col);
+        REQUIRE(r.height() == 1);
+        REQUIRE(r.width() == 1);
+        REQUIRE(r[0][0] == Catch::Approx(1.0 + 4.0 + 9.0));
+    }
+
+    SECTION("axpy on a single-column vector") {
+        Matrix x(4, 1, 1.0);
+        Matrix y(4, 1, 2.0);
+        x.axpy(-0.5, y);
+        for (std::size_t i = 0; i < 4; ++i) {
+            REQUIRE(x[i][0] == Catch::Approx(0.0));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape-preserving properties: transpose, identity, symmetry
+// ---------------------------------------------------------------------------
+TEST_CASE("Matrix transpose preserves values", "[matrix][basic]") {
     Matrix m(2, 3, 0.0);
-    m[0][0] = 1.0;
-    m[0][1] = 2.0;
-    m[0][2] = 3.0;
-    m[1][0] = 4.0;
-    m[1][1] = 5.0;
-    m[1][2] = 6.0;
+    fillSequential(m);
 
     Matrix t = m.transpose();
     REQUIRE(t.height() == 3);
@@ -35,23 +138,35 @@ TEST_CASE("Matrix transpose preserves values", "[matrix]") {
     REQUIRE(t[2][1] == 6.0);
 }
 
-TEST_CASE("Matrix dot multiplies small matrices", "[matrix]") {
+TEST_CASE("Transpose is an involution", "[matrix][property]") {
+    Matrix m(5, 7, 0.0);
+    fillSequential(m, -3.5, 0.25);
+
+    Matrix roundTrip = m.transpose().transpose();
+    REQUIRE(roundTrip.height() == m.height());
+    REQUIRE(roundTrip.width() == m.width());
+    for (std::size_t r = 0; r < m.height(); ++r) {
+        for (std::size_t c = 0; c < m.width(); ++c) {
+            // Transpose is a pure data move, so bit-equality is fine:
+            // no FP ops occur, so Catch::Approx is stricter than we need.
+            REQUIRE(roundTrip[r][c] == m[r][c]);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// dot()
+// ---------------------------------------------------------------------------
+TEST_CASE("Matrix dot multiplies small matrices", "[matrix][basic]") {
     Matrix a(2, 3, 0.0);
     Matrix b(3, 2, 0.0);
 
-    a[0][0] = 1.0;
-    a[0][1] = 2.0;
-    a[0][2] = 3.0;
-    a[1][0] = 4.0;
-    a[1][1] = 5.0;
-    a[1][2] = 6.0;
+    a[0][0] = 1.0; a[0][1] = 2.0; a[0][2] = 3.0;
+    a[1][0] = 4.0; a[1][1] = 5.0; a[1][2] = 6.0;
 
-    b[0][0] = 7.0;
-    b[0][1] = 8.0;
-    b[1][0] = 9.0;
-    b[1][1] = 10.0;
-    b[2][0] = 11.0;
-    b[2][1] = 12.0;
+    b[0][0] =  7.0; b[0][1] =  8.0;
+    b[1][0] =  9.0; b[1][1] = 10.0;
+    b[2][0] = 11.0; b[2][1] = 12.0;
 
     Matrix c = a.dot(b);
     REQUIRE(c.height() == 2);
@@ -62,7 +177,74 @@ TEST_CASE("Matrix dot multiplies small matrices", "[matrix]") {
     REQUIRE(c[1][1] == Catch::Approx(154.0));
 }
 
-TEST_CASE("Matrix axpy updates in place", "[matrix]") {
+TEST_CASE("A . I == A and I . A == A", "[matrix][property]") {
+    Matrix a(4, 6, 0.0);
+    fillSequential(a, 0.125, 0.375);
+
+    Matrix aI = a.dot(identity(6));
+    REQUIRE(aI.height() == 4);
+    REQUIRE(aI.width() == 6);
+    for (std::size_t r = 0; r < 4; ++r) {
+        for (std::size_t c = 0; c < 6; ++c) {
+            REQUIRE(aI[r][c] == Catch::Approx(a[r][c]));
+        }
+    }
+
+    Matrix Ia = identity(4).dot(a);
+    for (std::size_t r = 0; r < 4; ++r) {
+        for (std::size_t c = 0; c < 6; ++c) {
+            REQUIRE(Ia[r][c] == Catch::Approx(a[r][c]));
+        }
+    }
+}
+
+TEST_CASE("A . A^T is symmetric", "[matrix][property]") {
+    Matrix a(5, 3, 0.0);
+    fillSequential(a, 1.0, 0.5);
+
+    Matrix s = a.dot(a.transpose());
+    REQUIRE(s.height() == 5);
+    REQUIRE(s.width() == 5);
+    for (std::size_t r = 0; r < 5; ++r) {
+        for (std::size_t c = r + 1; c < 5; ++c) {
+            REQUIRE(s[r][c] == Catch::Approx(s[c][r]));
+        }
+    }
+}
+
+TEST_CASE("Matrix dot handles a larger shape", "[matrix][stress]") {
+    // 256x256 is large enough to exercise the tiled GEMM path's
+    // BI/BJ blocking (64x64) but small enough to stay inside a
+    // sanitizer's reasonable time budget.
+    constexpr std::size_t N = 256;
+    Matrix a(N, N, 0.0);
+    Matrix b(N, N, 0.0);
+
+    // Fill with a pattern that produces non-trivial sums.
+    for (std::size_t r = 0; r < N; ++r) {
+        for (std::size_t c = 0; c < N; ++c) {
+            a[r][c] = static_cast<double>((r + c) % 7);
+            b[r][c] = static_cast<double>((r * 3 + c) % 5);
+        }
+    }
+
+    Matrix c = a.dot(b);
+    REQUIRE(c.height() == N);
+    REQUIRE(c.width() == N);
+
+    // Spot-check one cell against a hand rollup; this is enough to
+    // catch any gross miscount in the tiled accumulator.
+    double expected00 = 0.0;
+    for (std::size_t k = 0; k < N; ++k) {
+        expected00 += a[0][k] * b[k][0];
+    }
+    REQUIRE(c[0][0] == Catch::Approx(expected00));
+}
+
+// ---------------------------------------------------------------------------
+// axpy + scalar ops
+// ---------------------------------------------------------------------------
+TEST_CASE("Matrix axpy updates in place", "[matrix][basic]") {
     Matrix x(2, 2, 1.0);
     Matrix y(2, 2, 2.0);
 
@@ -71,7 +253,155 @@ TEST_CASE("Matrix axpy updates in place", "[matrix]") {
     REQUIRE(x[1][1] == Catch::Approx(5.0));
 }
 
-TEST_CASE("Matrix stream round trip", "[matrix]") {
+TEST_CASE("axpy with alpha = 0 is a no-op", "[matrix][property]") {
+    Matrix x(3, 4, 7.5);
+    Matrix y(3, 4, 99.0);
+    x.axpy(0.0, y);
+
+    for (std::size_t r = 0; r < 3; ++r) {
+        for (std::size_t c = 0; c < 4; ++c) {
+            REQUIRE(x[r][c] == 7.5);  // exact: no FP op performed
+        }
+    }
+}
+
+TEST_CASE("Operator overloads behave element-wise", "[matrix][ops]") {
+    Matrix a(2, 2, 0.0);
+    Matrix b(2, 2, 0.0);
+    a[0][0] = 1.0; a[0][1] = 2.0; a[1][0] = 3.0; a[1][1] = 4.0;
+    b[0][0] = 5.0; b[0][1] = 6.0; b[1][0] = 7.0; b[1][1] = 8.0;
+
+    SECTION("addition") {
+        Matrix s = a + b;
+        REQUIRE(s[0][0] == Catch::Approx(6.0));
+        REQUIRE(s[1][1] == Catch::Approx(12.0));
+    }
+
+    SECTION("subtraction") {
+        Matrix d = b - a;
+        REQUIRE(d[0][0] == Catch::Approx(4.0));
+        REQUIRE(d[1][1] == Catch::Approx(4.0));
+    }
+
+    SECTION("Hadamard product via operator*") {
+        Matrix h = a * b;
+        REQUIRE(h[0][0] == Catch::Approx(5.0));
+        REQUIRE(h[1][1] == Catch::Approx(32.0));
+    }
+
+    SECTION("scalar multiply") {
+        Matrix s = a * 2.5;
+        REQUIRE(s[0][0] == Catch::Approx(2.5));
+        REQUIRE(s[1][1] == Catch::Approx(10.0));
+    }
+
+    SECTION("apply with std::negate") {
+        Matrix n = a.apply(std::negate<double>{});
+        REQUIRE(n[0][0] == Catch::Approx(-1.0));
+        REQUIRE(n[1][1] == Catch::Approx(-4.0));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage: NoInit tag + 64-byte alignment
+// ---------------------------------------------------------------------------
+TEST_CASE("NoInit tag allocates writable storage", "[matrix][storage]") {
+    // Using a somewhat oversized matrix so the uninitialized bytes
+    // are more likely to be non-zero under a debug allocator, making
+    // a post-fill verification meaningful.
+    Matrix m(8, 16, Matrix::NoInit{});
+    REQUIRE(m.height() == 8);
+    REQUIRE(m.width() == 16);
+    REQUIRE_FALSE(m.empty());
+
+    // Writability check: every cell must accept a store + readback.
+    for (std::size_t r = 0; r < 8; ++r) {
+        for (std::size_t c = 0; c < 16; ++c) {
+            m[r][c] = static_cast<double>(r * 16 + c);
+        }
+    }
+    for (std::size_t r = 0; r < 8; ++r) {
+        for (std::size_t c = 0; c < 16; ++c) {
+            REQUIRE(m[r][c] == static_cast<double>(r * 16 + c));
+        }
+    }
+}
+
+TEST_CASE("Matrix storage is 64-byte aligned", "[matrix][storage]") {
+    // allocate() uses posix_memalign/_aligned_malloc with 64 B alignment
+    // so SIMD kernels can safely use _mm512_load_pd / vld1q_f64.
+    // We reach into row 0's data() pointer via the Row proxy to avoid
+    // exposing the private data_ field.
+    Matrix m(4, 32, 0.0);
+    const Val* base = m[0].data();
+    REQUIRE(base != nullptr);
+    const auto addr = reinterpret_cast<std::uintptr_t>(base);
+    REQUIRE(addr % 64 == 0);
+}
+
+// ---------------------------------------------------------------------------
+// Copy + move semantics
+// ---------------------------------------------------------------------------
+TEST_CASE("Copy semantics deep-copy the storage", "[matrix][semantics]") {
+    Matrix original(3, 5, 0.0);
+    fillSequential(original);
+
+    SECTION("copy constructor produces an independent matrix") {
+        Matrix copy(original);
+        REQUIRE(copy.height() == original.height());
+        REQUIRE(copy.width() == original.width());
+        REQUIRE(copy[0].data() != original[0].data());
+
+        // Mutating the copy must not affect the source.
+        copy[0][0] = 999.0;
+        REQUIRE(original[0][0] == Catch::Approx(1.0));
+    }
+
+    SECTION("copy assignment produces an independent matrix") {
+        Matrix copy;
+        copy = original;
+        REQUIRE(copy.height() == original.height());
+        REQUIRE(copy.width() == original.width());
+        copy[2][4] = -1.0;
+        REQUIRE(original[2][4] == Catch::Approx(15.0));
+    }
+
+    SECTION("self-assignment is safe") {
+        Matrix m(2, 2, 0.0);
+        m[0][0] = 1.0; m[1][1] = 4.0;
+        Matrix& alias = m;
+        m = alias;  // must not UAF or double-free
+        REQUIRE(m[0][0] == Catch::Approx(1.0));
+        REQUIRE(m[1][1] == Catch::Approx(4.0));
+    }
+}
+
+TEST_CASE("Move semantics transfer storage without allocation",
+          "[matrix][semantics]") {
+    Matrix a(4, 4, 3.14);
+    const Val* originalData = a[0].data();
+
+    SECTION("move constructor") {
+        Matrix b(std::move(a));
+        REQUIRE(b.height() == 4);
+        REQUIRE(b.width() == 4);
+        REQUIRE(b[0].data() == originalData);  // same buffer
+        REQUIRE(a.empty());                    // moved-from is empty
+    }
+
+    SECTION("move assignment") {
+        Matrix b;
+        b = std::move(a);
+        REQUIRE(b.height() == 4);
+        REQUIRE(b[0].data() == originalData);
+        REQUIRE(a.empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stream round-trip
+// ---------------------------------------------------------------------------
+TEST_CASE("Matrix stream round trip", "[matrix][io]") {
     Matrix m(2, 2, 0.0);
     m[0][0] = 1.0;
     m[0][1] = 2.0;
@@ -88,4 +418,37 @@ TEST_CASE("Matrix stream round trip", "[matrix]") {
     REQUIRE(loaded.width() == 2);
     REQUIRE(loaded[1][0] == Catch::Approx(3.0));
     REQUIRE(loaded[0][1] == Catch::Approx(2.0));
+}
+
+TEST_CASE("Stream round trip preserves non-round doubles",
+          "[matrix][io][property]") {
+    // 7x11 with irregular values exercises the text-format
+    // serializer at a non-power-of-two shape where ld_ padding
+    // diverges from cols_.
+    Matrix m(7, 11, 0.0);
+    for (std::size_t r = 0; r < m.height(); ++r) {
+        for (std::size_t c = 0; c < m.width(); ++c) {
+            m[r][c] =
+                std::sin(static_cast<double>(r) * 0.3 + c * 0.7) * 12.34567;
+        }
+    }
+
+    std::stringstream ss;
+    ss.precision(17);  // round-trip-safe precision for IEEE-754 double
+    ss << m;
+
+    Matrix loaded;
+    ss >> loaded;
+
+    REQUIRE(loaded.height() == m.height());
+    REQUIRE(loaded.width() == m.width());
+    for (std::size_t r = 0; r < m.height(); ++r) {
+        for (std::size_t c = 0; c < m.width(); ++c) {
+            // Approx here covers any minute rounding the default
+            // stream precision might introduce; we explicitly set
+            // precision(17) above, which is enough for full-precision
+            // round-trip on IEEE-754 double.
+            REQUIRE(loaded[r][c] == Catch::Approx(m[r][c]));
+        }
+    }
 }

--- a/tests/test_matrix_properties.cpp
+++ b/tests/test_matrix_properties.cpp
@@ -1,0 +1,188 @@
+// Property-based tests for the Matrix kernel using rapidcheck.
+//
+// rapidcheck generates thousands of random inputs per property and
+// shrinks failing cases down to a minimal counterexample. We pair it
+// with Catch2 via rapidcheck/catch.h so failing properties surface in
+// the normal ctest output.
+//
+// Edge-case floating point is treacherous under generators: if
+// rapidcheck happens to draw a NaN or an Inf, most correctness
+// properties will fail for reasons that are not actually bugs.
+// Every generator in this file clamps its doubles to a finite
+// well-behaved range.
+
+#include <catch2/catch_test_macros.hpp>
+#include <rapidcheck.h>
+#include <rapidcheck/catch.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "fast_mnist/Matrix.h"
+
+namespace {
+
+// Generate a single finite double in [-10, 10]. Tight range keeps
+// the accumulator errors small enough that the tolerance checks do
+// not need to be adaptive.
+rc::Gen<double> boundedDouble() {
+    return rc::gen::map(rc::gen::arbitrary<int>(), [](int n) {
+        // Map an arbitrary int into a deterministic finite double.
+        // Using fmod + normalization avoids ever producing NaN/Inf.
+        const double raw = static_cast<double>(n) * 1e-6;
+        double v = std::fmod(raw, 20.0);
+        if (std::isnan(v) || std::isinf(v))
+            v = 0.0;
+        return v - 10.0;
+    });
+}
+
+// Shape generator that keeps matrices small enough for rapidcheck to
+// run many iterations per case; large random GEMMs would starve the
+// test budget.
+struct Shape {
+    std::size_t rows;
+    std::size_t cols;
+};
+
+rc::Gen<Shape> shape(std::size_t maxDim = 8) {
+    return rc::gen::construct<Shape>(
+        rc::gen::inRange<std::size_t>(1, maxDim + 1),
+        rc::gen::inRange<std::size_t>(1, maxDim + 1));
+}
+
+// Build a Matrix filled from a flat vector in row-major order. If the
+// vector is smaller than rows*cols the remainder is zero-filled; if
+// it is larger the tail is discarded.
+Matrix makeMatrix(std::size_t rows, std::size_t cols,
+                  const std::vector<double>& flat) {
+    Matrix m(rows, cols, 0.0);
+    std::size_t idx = 0;
+    for (std::size_t r = 0; r < rows; ++r) {
+        for (std::size_t c = 0; c < cols; ++c) {
+            m[r][c] = (idx < flat.size()) ? flat[idx] : 0.0;
+            ++idx;
+        }
+    }
+    return m;
+}
+
+} // namespace
+
+TEST_CASE("rapidcheck: transpose is an involution",
+          "[matrix][property][rapidcheck]") {
+    rc::prop("transpose(transpose(A)) == A", []() {
+        const Shape s = *shape();
+        const auto values =
+            *rc::gen::container<std::vector<double>>(s.rows * s.cols,
+                                                     boundedDouble());
+        Matrix a = makeMatrix(s.rows, s.cols, values);
+        Matrix roundTrip = a.transpose().transpose();
+
+        RC_ASSERT(roundTrip.height() == a.height());
+        RC_ASSERT(roundTrip.width() == a.width());
+        for (std::size_t r = 0; r < a.height(); ++r) {
+            for (std::size_t c = 0; c < a.width(); ++c) {
+                // Transpose is a pure data move, no FP op: exact.
+                RC_ASSERT(roundTrip[r][c] == a[r][c]);
+            }
+        }
+    });
+}
+
+TEST_CASE("rapidcheck: axpy with alpha = 0 is a no-op",
+          "[matrix][property][rapidcheck]") {
+    rc::prop("alpha=0 leaves LHS untouched", []() {
+        const Shape s = *shape();
+        const auto xVals =
+            *rc::gen::container<std::vector<double>>(s.rows * s.cols,
+                                                     boundedDouble());
+        const auto yVals =
+            *rc::gen::container<std::vector<double>>(s.rows * s.cols,
+                                                     boundedDouble());
+        Matrix x = makeMatrix(s.rows, s.cols, xVals);
+        Matrix y = makeMatrix(s.rows, s.cols, yVals);
+        Matrix xCopy = x;
+
+        x.axpy(0.0, y);
+
+        for (std::size_t r = 0; r < s.rows; ++r) {
+            for (std::size_t c = 0; c < s.cols; ++c) {
+                // Exact: axpy with alpha=0 must perform zero FP ops.
+                RC_ASSERT(x[r][c] == xCopy[r][c]);
+            }
+        }
+    });
+}
+
+TEST_CASE("rapidcheck: matmul shape is preserved",
+          "[matrix][property][rapidcheck]") {
+    // For A (m x k) and B (k x n), A.dot(B) must have shape m x n.
+    rc::prop("shape(A.dot(B)) == (A.rows, B.cols)", []() {
+        // Draw three independent dims and compose two matrices whose
+        // inner dimension matches by construction.
+        const std::size_t m = *rc::gen::inRange<std::size_t>(1, 9);
+        const std::size_t k = *rc::gen::inRange<std::size_t>(1, 9);
+        const std::size_t n = *rc::gen::inRange<std::size_t>(1, 9);
+
+        const auto lhsVals = *rc::gen::container<std::vector<double>>(
+            m * k, boundedDouble());
+        const auto rhsVals = *rc::gen::container<std::vector<double>>(
+            k * n, boundedDouble());
+
+        Matrix A = makeMatrix(m, k, lhsVals);
+        Matrix B = makeMatrix(k, n, rhsVals);
+
+        Matrix C = A.dot(B);
+        RC_ASSERT(C.height() == m);
+        RC_ASSERT(C.width() == n);
+    });
+}
+
+TEST_CASE("rapidcheck: dot with zero matrix is zero",
+          "[matrix][property][rapidcheck]") {
+    rc::prop("A.dot(0) == 0", []() {
+        const Shape s = *shape();
+        const auto vals = *rc::gen::container<std::vector<double>>(
+            s.rows * s.cols, boundedDouble());
+        Matrix A = makeMatrix(s.rows, s.cols, vals);
+        Matrix Zero(s.cols, s.cols, 0.0);
+
+        Matrix C = A.dot(Zero);
+        RC_ASSERT(C.height() == s.rows);
+        RC_ASSERT(C.width() == s.cols);
+        for (std::size_t r = 0; r < C.height(); ++r) {
+            for (std::size_t c = 0; c < C.width(); ++c) {
+                // Exact zero: 0 * x + 0 * y + ... is exactly zero in
+                // IEEE-754 regardless of x,y, barring NaN/Inf which
+                // we've already filtered out in boundedDouble().
+                RC_ASSERT(C[r][c] == 0.0);
+            }
+        }
+    });
+}
+
+TEST_CASE("rapidcheck: addition is commutative",
+          "[matrix][property][rapidcheck]") {
+    rc::prop("A + B == B + A", []() {
+        const Shape s = *shape();
+        const auto va = *rc::gen::container<std::vector<double>>(
+            s.rows * s.cols, boundedDouble());
+        const auto vb = *rc::gen::container<std::vector<double>>(
+            s.rows * s.cols, boundedDouble());
+        Matrix A = makeMatrix(s.rows, s.cols, va);
+        Matrix B = makeMatrix(s.rows, s.cols, vb);
+
+        Matrix AB = A + B;
+        Matrix BA = B + A;
+        for (std::size_t r = 0; r < s.rows; ++r) {
+            for (std::size_t c = 0; c < s.cols; ++c) {
+                // Commutativity of + is exact in IEEE-754 as long as
+                // neither operand is NaN.
+                RC_ASSERT(AB[r][c] == BA[r][c]);
+            }
+        }
+    });
+}

--- a/tests/test_neural_net.cpp
+++ b/tests/test_neural_net.cpp
@@ -1,7 +1,11 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
+#include <numeric>
+#include <random>
 #include <sstream>
 #include <vector>
 
@@ -10,6 +14,18 @@
 
 namespace {
 
+// Shim that exposes NeuralNet's protected static helpers so tests can
+// validate sigmoid/invSigmoid directly without shelling them through a
+// full forward pass.
+class NeuralNetSpy : public NeuralNet {
+  public:
+    using NeuralNet::invSigmoid;
+    using NeuralNet::sigmoid;
+    NeuralNetSpy() : NeuralNet({1, 1}) {}
+};
+
+// Build the serialized form of a zero-weight 2-2-2 net. Useful for
+// sanity-checking the stream operators on a trivial fixture.
 std::string makeZeroNetStream() {
     Matrix layerSizes(1, 3, 0.0);
     layerSizes[0][0] = 2.0;
@@ -22,11 +38,9 @@ std::string makeZeroNetStream() {
     Matrix w2(2, 2, 0.0);
 
     std::ostringstream os;
-    os << layerSizes << '\n';
-    os << b1 << '\n';
-    os << b2 << '\n';
-    os << w1 << '\n';
-    os << w2 << '\n';
+    os.precision(17);
+    os << layerSizes << '\n' << b1 << '\n' << b2 << '\n'
+       << w1 << '\n' << w2 << '\n';
     return os.str();
 }
 
@@ -39,39 +53,34 @@ std::string makeTinyNetStream() {
     layerSizes[0][1] = 3.0;
     layerSizes[0][2] = 2.0;
 
-    // Biases: one column per layer (hidden, output).
     Matrix b1(3, 1, 0.0);
-    b1[0][0] = 0.1;
-    b1[1][0] = -0.2;
-    b1[2][0] = 0.05;
+    b1[0][0] = 0.1;  b1[1][0] = -0.2; b1[2][0] = 0.05;
 
     Matrix b2(2, 1, 0.0);
-    b2[0][0] = -0.1;
-    b2[1][0] = 0.2;
+    b2[0][0] = -0.1; b2[1][0] = 0.2;
 
-    // W0: 3x2 (hidden x input).
     Matrix w1(3, 2, 0.0);
-    w1[0][0] = 0.5;  w1[0][1] = -0.3;
-    w1[1][0] = 0.1;  w1[1][1] = 0.4;
-    w1[2][0] = -0.2; w1[2][1] = 0.7;
+    w1[0][0] =  0.5; w1[0][1] = -0.3;
+    w1[1][0] =  0.1; w1[1][1] =  0.4;
+    w1[2][0] = -0.2; w1[2][1] =  0.7;
 
-    // W1: 2x3 (output x hidden).
     Matrix w2(2, 3, 0.0);
-    w2[0][0] = 0.3;  w2[0][1] = -0.5; w2[0][2] = 0.2;
-    w2[1][0] = -0.1; w2[1][1] = 0.6;  w2[1][2] = 0.4;
+    w2[0][0] =  0.3; w2[0][1] = -0.5; w2[0][2] = 0.2;
+    w2[1][0] = -0.1; w2[1][1] =  0.6; w2[1][2] = 0.4;
 
     std::ostringstream os;
-    os << layerSizes << '\n';
-    os << b1 << '\n';
-    os << b2 << '\n';
-    os << w1 << '\n';
-    os << w2 << '\n';
+    os.precision(17);
+    os << layerSizes << '\n' << b1 << '\n' << b2 << '\n'
+       << w1 << '\n' << w2 << '\n';
     return os.str();
 }
 
 } // namespace
 
-TEST_CASE("NeuralNet loads from stream", "[neural_net]") {
+// ---------------------------------------------------------------------------
+// Forward pass: stream round-trip, hidden activations, consistency
+// ---------------------------------------------------------------------------
+TEST_CASE("NeuralNet loads from stream", "[neural_net][io]") {
     NeuralNet net({1, 1});
     std::istringstream is(makeZeroNetStream());
     is >> net;
@@ -84,8 +93,41 @@ TEST_CASE("NeuralNet loads from stream", "[neural_net]") {
 
     REQUIRE(out.height() == 2);
     REQUIRE(out.width() == 1);
+    // All weights + biases zero -> sigmoid(0) = 0.5 on every layer.
     REQUIRE(out[0][0] == Catch::Approx(0.5));
     REQUIRE(out[1][0] == Catch::Approx(0.5));
+}
+
+TEST_CASE("Multi-layer stream round-trip preserves classification",
+          "[neural_net][io]") {
+    // Use a non-trivial 3-layer {4, 5, 3} net so the serialized form
+    // carries two weight matrices with different shapes. A silent
+    // shape mismatch in the reader would almost certainly produce
+    // different output activations on the same input.
+    NeuralNet original({4, 5, 3});
+
+    // Same fixed input for both forward passes.
+    Matrix input(4, 1, 0.0);
+    input[0][0] = 0.1;
+    input[1][0] = -0.4;
+    input[2][0] = 0.7;
+    input[3][0] = 0.25;
+
+    Matrix originalOut = original.classify(input);
+
+    std::stringstream ss;
+    ss.precision(17);
+    ss << original;
+
+    NeuralNet loaded({1, 1});
+    ss >> loaded;
+
+    Matrix loadedOut = loaded.classify(input);
+    REQUIRE(loadedOut.height() == originalOut.height());
+    REQUIRE(loadedOut.width() == originalOut.width());
+    for (std::size_t i = 0; i < originalOut.height(); ++i) {
+        REQUIRE(loadedOut[i][0] == Catch::Approx(originalOut[i][0]));
+    }
 }
 
 TEST_CASE("classifyWithHidden exposes hidden activations",
@@ -101,21 +143,47 @@ TEST_CASE("classifyWithHidden exposes hidden activations",
     std::vector<Val> hidden;
     Matrix out = net.classifyWithHidden(input, hidden);
 
-    // Hidden width matches the middle layer ({2, 3, 2}).
     REQUIRE(hidden.size() == 3);
     for (double h : hidden) {
         REQUIRE(h > 0.0);
         REQUIRE(h < 1.0);
     }
 
-    // Output activations match the plain classify() path, confirming
-    // no drift between the two forward paths.
     Matrix refOut = net.classify(input);
     REQUIRE(out.height() == refOut.height());
     REQUIRE(out[0][0] == Catch::Approx(refOut[0][0]));
     REQUIRE(out[1][0] == Catch::Approx(refOut[1][0]));
 }
 
+TEST_CASE("classifyWithHidden is deterministic across repeated calls",
+          "[neural_net][interpretability]") {
+    NeuralNet net({1, 1});
+    std::istringstream is(makeTinyNetStream());
+    is >> net;
+
+    Matrix input(2, 1, 0.0);
+    input[0][0] = 0.42;
+    input[1][0] = -0.17;
+
+    std::vector<Val> hidden1, hidden2;
+    Matrix out1 = net.classifyWithHidden(input, hidden1);
+    Matrix out2 = net.classifyWithHidden(input, hidden2);
+
+    REQUIRE(hidden1.size() == hidden2.size());
+    for (std::size_t i = 0; i < hidden1.size(); ++i) {
+        // Forward pass is pure arithmetic on the same inputs + weights,
+        // so bit-equality is the right contract here: any drift would
+        // indicate hidden static state or UB.
+        REQUIRE(hidden1[i] == hidden2[i]);
+    }
+    for (std::size_t i = 0; i < out1.height(); ++i) {
+        REQUIRE(out1[i][0] == out2[i][0]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backward pass / saliency
+// ---------------------------------------------------------------------------
 TEST_CASE("computeInputGradient returns input-sized saliency",
           "[neural_net][interpretability]") {
     NeuralNet net({1, 1});
@@ -150,8 +218,177 @@ TEST_CASE("computeInputGradient returns input-sized saliency",
         perturbed[i][0] += eps;
         Matrix pOut = net.classify(perturbed);
         const double fdGrad = (pOut[0][0] - baseOut[0][0]) / eps;
-        // Loose tolerance -- finite differences at 1e-6 on a
-        // sigmoid stack are typically accurate to ~1e-4.
         REQUIRE(std::abs(grad[i] - fdGrad) < 5e-4);
+    }
+}
+
+TEST_CASE("computeInputGradient agrees with finite differences within 5%",
+          "[neural_net][interpretability]") {
+    NeuralNet net({1, 1});
+    std::istringstream is(makeTinyNetStream());
+    is >> net;
+
+    // Input chosen so all activations sit well inside (0.1, 0.9) --
+    // keeps a*(1-a) large enough that the 1e-6 finite-difference
+    // noise stays below the relative-error tolerance.
+    Matrix input(2, 1, 0.0);
+    input[0][0] = 0.3;
+    input[1][0] = -0.2;
+
+    // Cycle through each target class -- any drift between forward
+    // and backward across classes would show up here.
+    for (int target = 0; target < 2; ++target) {
+        std::vector<Val> grad;
+        net.computeInputGradient(input, target, grad);
+        REQUIRE(grad.size() == 2);
+
+        const double eps = 1e-6;
+        Matrix baseOut = net.classify(input);
+        for (int i = 0; i < 2; ++i) {
+            Matrix perturbed = input;
+            perturbed[i][0] += eps;
+            Matrix pOut = net.classify(perturbed);
+            const double fd =
+                (pOut[target][0] - baseOut[target][0]) / eps;
+
+            // Relative error, floored at an absolute tolerance so we
+            // don't blow up on gradients that are essentially zero.
+            const double denom =
+                std::max(std::abs(fd), 1e-4);
+            const double relErr = std::abs(grad[i] - fd) / denom;
+            REQUIRE(relErr < 0.05);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Weight init sanity
+// ---------------------------------------------------------------------------
+TEST_CASE("Xavier init produces zero-mean, ~1/sqrt(fan_in) stddev weights",
+          "[neural_net][init]") {
+    // Large-ish hidden layer so the sample is big enough to get
+    // stable moments out of a single draw. initBiasAndWeightMatrices
+    // uses a static RNG seeded from std::random_device, which is why
+    // this test uses broad 50% tolerances instead of tight bounds.
+    const int fanIn = 256;
+    const int hidden = 128;
+    NeuralNet net({fanIn, hidden, 10});
+    const auto& weights = net.getWeights();
+    REQUIRE(weights.size() == 2);
+
+    const Matrix& W0 = weights[0];
+    REQUIRE(W0.height() == static_cast<std::size_t>(hidden));
+    REQUIRE(W0.width() == static_cast<std::size_t>(fanIn));
+
+    // Compute mean + stddev across the hidden x fan_in block.
+    double sum = 0.0, sumSq = 0.0;
+    std::size_t n = 0;
+    for (std::size_t r = 0; r < W0.height(); ++r) {
+        for (std::size_t c = 0; c < W0.width(); ++c) {
+            const double w = W0[r][c];
+            sum += w;
+            sumSq += w * w;
+            ++n;
+        }
+    }
+    const double mean = sum / static_cast<double>(n);
+    const double var =
+        sumSq / static_cast<double>(n) - mean * mean;
+    const double stddev = std::sqrt(var);
+    const double expectedStddev = 1.0 / std::sqrt(static_cast<double>(fanIn));
+
+    // Mean should be small relative to stddev.
+    REQUIRE(std::abs(mean) < 0.2 * expectedStddev);
+    // Stddev within 50% of the Xavier target.
+    REQUIRE(stddev > 0.5 * expectedStddev);
+    REQUIRE(stddev < 1.5 * expectedStddev);
+}
+
+// ---------------------------------------------------------------------------
+// Learning on XOR
+// ---------------------------------------------------------------------------
+TEST_CASE("NeuralNet learns XOR within 20k SGD steps",
+          "[neural_net][learning][slow]") {
+    // A 2-4-1 net is overkill for XOR but keeps the training budget
+    // well inside the sanitizer CI cell's time envelope. Tag [.slow]
+    // so it's still discoverable via `ctest -L slow`; default run
+    // executes it.
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+    // Training data: the 4 XOR points.
+    const double X[4][2] = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
+    const double Y[4] = {0, 1, 1, 0};
+
+    // Single best-of-N attempt; the RNG is std::random_device in
+    // initBiasAndWeightMatrices so we cannot seed it from here, and
+    // a single 2-4-1 net occasionally fails to escape a bad init.
+    // Try up to 3 fresh initialisations; 20k steps each is still
+    // under one sanitizer-cell second.
+    bool converged = false;
+    for (int attempt = 0; attempt < 3 && !converged; ++attempt) {
+        NeuralNet net({2, 4, 1});
+
+        Matrix in(2, 1, 0.0);
+        Matrix target(1, 1, 0.0);
+
+        const int iters = 20000;
+        for (int step = 0; step < iters; ++step) {
+            const int idx = step % 4;
+            in[0][0] = X[idx][0];
+            in[1][0] = X[idx][1];
+            target[0][0] = Y[idx];
+            net.learn(in, target, 1.0);
+        }
+
+        int correct = 0;
+        for (int i = 0; i < 4; ++i) {
+            in[0][0] = X[i][0];
+            in[1][0] = X[i][1];
+            Matrix out = net.classify(in);
+            const double predicted = out[0][0] >= 0.5 ? 1.0 : 0.0;
+            if (predicted == Y[i])
+                ++correct;
+        }
+        if (correct == 4) {
+            converged = true;
+        }
+
+        // Suppress the unused dist/gen warning the CI compilers
+        // sometimes emit; they are kept for future extensions.
+        (void)dist;
+        (void)gen;
+    }
+
+    REQUIRE(converged);
+}
+
+// ---------------------------------------------------------------------------
+// Activation + derivative sanity
+// ---------------------------------------------------------------------------
+TEST_CASE("sigmoid and invSigmoid match analytic values",
+          "[neural_net][activation]") {
+    // sigmoid(0) is exactly 1/2 in IEEE-754 arithmetic: exp(-0)=1,
+    // 1/(1+1) = 0.5. Any drift here would point to a broken
+    // activation function.
+    REQUIRE(NeuralNetSpy::sigmoid(0.0) == 0.5);
+
+    // Saturates cleanly at large positive arguments.
+    REQUIRE(NeuralNetSpy::sigmoid(1000.0) == Catch::Approx(1.0));
+    // And at large negative arguments.
+    REQUIRE(NeuralNetSpy::sigmoid(-1000.0) == Catch::Approx(0.0));
+
+    // invSigmoid(x) = sigmoid(x) * (1 - sigmoid(x)) = sigma'(x).
+    // At x=0 this is 0.5 * 0.5 = 0.25.
+    REQUIRE(NeuralNetSpy::invSigmoid(0.0) == Catch::Approx(0.25));
+
+    // Validate the analytic derivative against a centered
+    // finite-difference of sigmoid at a few probe points.
+    for (double x : {-2.0, -0.5, 0.5, 2.0}) {
+        const double eps = 1e-5;
+        const double fd =
+            (NeuralNetSpy::sigmoid(x + eps) - NeuralNetSpy::sigmoid(x - eps))
+            / (2.0 * eps);
+        REQUIRE(std::abs(NeuralNetSpy::invSigmoid(x) - fd) < 1e-6);
     }
 }


### PR DESCRIPTION
## Summary
Lifts test rigor from "hobby" (8 tests, no sanitizer CI) to "senior portfolio" (32 tests + a sanitizer matrix + property-based fuzzing).

## Why
The library ships hand-written AVX-512 / AVX-2 / NEON SIMD kernels, raw `posix_memalign` storage, and OpenMP parallel loops, and there was zero sanitizer coverage. The existing suite was 5 matrix cases + 3 neural-net cases, all happy-path at tiny shapes. A single off-by-one in a SIMD tail loop or a missing `std::memset` in the `NoInit` path would only surface as a silent miscompare; we'd never see it.

## Changes

### CI + build
- `build(cmake): add FAST_MNIST_ENABLE_SANITIZERS option` — cache STRING accepting `OFF | asan | ubsan | asan-ubsan | tsan | msan`, applied PUBLIC on the library target so flags propagate to all downstream consumers (CLI, trainer, server, tests, benchmarks). MSan documented as manual-only; unknown values -> `FATAL_ERROR`.
- `ci(sanitizers): add ASan+UBSan + TSan matrix workflow` — new `.github/workflows/sanitizers.yml`: `{ubuntu, macOS} x {asan-ubsan, tsan} x {clang, gcc}`, macOS+gcc excluded. `ASAN/UBSAN/TSAN_OPTIONS` set so a sanitizer report returns non-zero. TSan cells force `FAST_MNIST_ENABLE_OPENMP=OFF` to avoid OpenMP-runtime false positives. `concurrency` group cancels superseded runs.
- `ci(sanitizers): skip LSan on macOS, enable on Linux only` — follow-up: LSan is Linux-only; `detect_leaks=1` crashes macOS ASan at startup, so it's appended at step time, gated on `RUNNER_OS=Linux` and non-TSan.
- `build(cmake): fetch rapidcheck for property tests` — pin to commit `b96a4e6`, skip rapidcheck's vendored Catch2 v2 (`RC_ENABLE_CATCH=OFF`), manually `add_subdirectory` the header-only `extras/catch` INTERFACE target.
- `build(scripts): bench.sh reproducibility harness` — 10-repetitions-aggregated JSON output, best-effort `cpupower` governor pin on Linux.

### Tests
- `test(matrix): expand matrix suite from 5 to 18 cases` — empty matrices, row/col vectors, involution of transpose, `A.I==A`, `A.A^T` symmetry, 256x256 tiled GEMM spot-check, `axpy(0, ...)` no-op, operator overloads, `NoInit` + 64-byte alignment, copy + move + self-assignment semantics, stream round-trip at 7x11 with non-round doubles.
- `test(neuralnet): XOR convergence + gradient finite-diffs` — 109 -> ~300 lines: multi-layer stream round-trip, `classifyWithHidden` determinism, FD gradient check w/ 5% relative tolerance over both classes, Xavier init distribution sanity, XOR convergence in 20k steps (best-of-3 because the RNG isn't seedable), `sigmoid`/`invSigmoid` analytic check using a protected-access `NeuralNetSpy`.
- `test(matrix): rapidcheck property tests for core kernels` — 5 properties, 100 iterations each: transpose involution, axpy(0) no-op, matmul shape preservation, `A.Zero == Zero`, addition commutativity. Bounded-double generator to avoid NaN/Inf.

## Test plan
- [x] `cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build && ctest --test-dir build` -> 32/32 pass (0.12s), was 8/8
- [x] `cmake -S . -B build-san -DFAST_MNIST_ENABLE_SANITIZERS=asan-ubsan -DCMAKE_BUILD_TYPE=Debug && ASAN_OPTIONS=halt_on_error=1 ctest --test-dir build-san` -> 32/32 pass (2.3s), no sanitizer reports
- [x] XOR test run 5 times standalone -> 5/5 pass
- [x] `./build/fast_mnist_tests "[rapidcheck]"` with `RC_PARAMS=verbose_progress=1` -> ~100 iterations per property
- [ ] CI sanitizer matrix green (will verify on push)
- [x] `git log --format=%B feat/test-rigor-foundation ^origin/optimization | grep -ci "claude\|anthropic\|co-authored"` -> 0

## Test count delta
- Before: 8 ctest cases (`ctest -N`)
- After: 32 ctest cases (5 rapidcheck + 18 matrix + 9 neural-net)

## Rollback
Revert the merge commit; no runtime or ABI changes. CMake option defaults to `OFF`, so existing consumers get identical builds.

## Follow-ups
- CodSpeed / bench-action gate consuming `scripts/bench.sh` output (Phase 6).
- MSan once we can bake an instrumented libc++ in a Docker image.