### PR TITLE
fix(hygiene): disable commitlint subject-case rule

### DIFF
--- a/web/commitlint.config.mjs
+++ b/web/commitlint.config.mjs
@@ -14,9 +14,13 @@ export default {
 
     // Blank-line rules: warn, don't block. Squash merges can collapse
     // the leading blank line between body and footer; not worth failing
-    // the build over.
     'body-leading-blank': [1, 'always'],
     'footer-leading-blank': [1, 'always'],
+
+    // Case rules disabled: we often use acronyms in subjects ("ADR-0001",
+    // "SIMD", "OKLCH", "MLP", "WASM") which config-conventional flags as
+    // pascal/upper-case. Not worth the noise.
+    'subject-case': [0],
 
     // Type must be one of these.
     'type-enum': [


### PR DESCRIPTION
## Summary
Disable `subject-case` — flags common acronyms (ADR-N, SIMD, OKLCH, MLP, WASM) as pascal/upper case. Unblocks PR #75.

## Why
PR #75 commit subjects include `ADR-0001` which triggers the rule. Rewriting merged commits isn't worth it; disabling a noisy rule is.

## Changes
- `web/commitlint.config.mjs`: `'subject-case': [0]`

## Test plan
- [ ] Commitlint CI passes on this PR
- [ ] PR #75 CI re-runs green after this merges

## Breaking changes
None.

## Rollback plan
Revert the PR.