### PR TITLE
ci(security): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,64 @@
+name: OpenSSF Scorecard
+
+# OpenSSF Scorecard analyzes the repo against 18 supply-chain security
+# checks (code review, branch protection, signed releases, dependency
+# update tooling, SAST, etc.) and publishes the score publicly at
+# https://scorecard.dev/viewer/?uri=github.com/yadava5/fast-mnist-nn.
+#
+# Docs: https://github.com/ossf/scorecard-action
+
+on:
+  # Re-analyze whenever a branch-protection rule changes, on push to
+  # main, weekly, and on manual dispatch.
+  branch_protection_rule:
+  schedule:
+    - cron: '0 4 * * 1'   # every Monday 04:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Global minimal permissions; the analysis job escalates what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # needed to upload SARIF into code scanning
+      security-events: write
+      # needed for the OIDC identity used by the publish_results flag
+      id-token: write
+      # needed to read the repository
+      contents: read
+      # needed to enumerate workflows/runs for several checks
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Scorecard reads git metadata via the GitHub API with its own
+          # token; leave the checkout token out of the workspace.
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results lets scorecard.dev host a public badge for
+          # this repo. Requires id-token: write above.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 14
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Adds `.github/workflows/scorecard.yml` — OpenSSF Scorecard analysis on push-to-main, weekly cron, branch-protection changes, and manual dispatch. Publishes results to `scorecard.dev` and surfaces findings in GitHub code scanning.

## Why
Scorecard is the canonical supply-chain health metric for public OSS repos in 2026. With CodeQL + Dependabot + gitleaks + signed releases (pending) already in place, we expect a score around 7-8/10 out of the box — a strong portfolio signal for a solo-maintained repo.

## Changes
- `.github/workflows/scorecard.yml` — permissions scoped correctly (`read-all` globally, analysis job escalates), `ossf/scorecard-action@v2.4.0`, SARIF uploaded as 14-day artifact + code-scanning alert.

## Test plan
- [x] YAML validates
- [ ] First run fires on push-to-main after this + optimization → main merges; results visible at https://scorecard.dev/viewer/?uri=github.com/yadava5/fast-mnist-nn

## Breaking changes
None.

## Rollback plan
Revert the workflow file.

## Follow-ups
- README badge (separate PR on hygiene track)
- SLSA build provenance on releases
- CycloneDX SBOM on releases
- Branch-protection ruleset on main (user-confirmed)
