### PR TITLE
ci(security): add release SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-release:
@@ -54,15 +54,30 @@ jobs:
   publish-release:
     runs-on: ubuntu-latest
     needs: build-release
+    permissions:
+      actions: read
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist
 
+      - name: Generate release SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: dist
+          format: spdx-json
+          output-file: dist/fast_mnist_cli-release-sbom.spdx.json
+          artifact-name: fast_mnist_cli-release-sbom.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3
         with:
           name: Initial release
           generate_release_notes: true
-          files: dist/**/*.zip
+          files: |
+            dist/**/*.zip
+            dist/fast_mnist_cli-release-sbom.spdx.json


### PR DESCRIPTION
Summary: Adds Anchore Syft SBOM generation to the release publish job and attaches the SPDX JSON SBOM alongside release ZIPs. Test plan: ruby YAML parse passed; git diff --check passed; act dry-run was attempted but blocked by local Docker host lookup before workflow evaluation.