### PR TITLE
ci(security): attest release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,10 @@ jobs:
     needs: build-release
     permissions:
       actions: read
+      artifact-metadata: write
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -72,6 +75,17 @@ jobs:
           artifact-name: fast_mnist_cli-release-sbom.spdx.json
           upload-artifact: true
           upload-release-assets: false
+
+      - name: Attest release artifacts
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/**/*.zip
+
+      - name: Attest release SBOM
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/**/*.zip
+          sbom-path: dist/fast_mnist_cli-release-sbom.spdx.json
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
Summary: Adds GitHub Artifact Attestations for release ZIP artifacts and an SBOM attestation for the generated SPDX SBOM using actions/attest@v4. Test plan: ruby YAML parse passed; git diff --check passed; commit attribution audit returned 0.