### PR TITLE
ci(security): add OpenSSF release provenance polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,10 @@ jobs:
     needs: build-release
     permissions:
       actions: read
+      artifact-metadata: write
+      attestations: write
       contents: write
+      id-token: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -72,6 +75,17 @@ jobs:
           artifact-name: fast_mnist_cli-release-sbom.spdx.json
           upload-artifact: true
           upload-release-assets: false
+
+      - name: Attest release artifacts
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/**/*.zip
+
+      - name: Attest release SBOM
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/**/*.zip
+          sbom-path: dist/fast_mnist_cli-release-sbom.spdx.json
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-release:
@@ -54,15 +54,30 @@ jobs:
   publish-release:
     runs-on: ubuntu-latest
     needs: build-release
+    permissions:
+      actions: read
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist
 
+      - name: Generate release SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: dist
+          format: spdx-json
+          output-file: dist/fast_mnist_cli-release-sbom.spdx.json
+          artifact-name: fast_mnist_cli-release-sbom.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v3
         with:
           name: Initial release
           generate_release_notes: true
-          files: dist/**/*.zip
+          files: |
+            dist/**/*.zip
+            dist/fast_mnist_cli-release-sbom.spdx.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,64 @@
+name: OpenSSF Scorecard
+
+# OpenSSF Scorecard analyzes the repo against 18 supply-chain security
+# checks (code review, branch protection, signed releases, dependency
+# update tooling, SAST, etc.) and publishes the score publicly at
+# https://scorecard.dev/viewer/?uri=github.com/yadava5/fast-mnist-nn.
+#
+# Docs: https://github.com/ossf/scorecard-action
+
+on:
+  # Re-analyze whenever a branch-protection rule changes, on push to
+  # main, weekly, and on manual dispatch.
+  branch_protection_rule:
+  schedule:
+    - cron: '0 4 * * 1'   # every Monday 04:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Global minimal permissions; the analysis job escalates what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # needed to upload SARIF into code scanning
+      security-events: write
+      # needed for the OIDC identity used by the publish_results flag
+      id-token: write
+      # needed to read the repository
+      contents: read
+      # needed to enumerate workflows/runs for several checks
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Scorecard reads git metadata via the GitHub API with its own
+          # token; leave the checkout token out of the workspace.
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # publish_results lets scorecard.dev host a public badge for
+          # this repo. Requires id-token: write above.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 14
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Summary:
- Adds the OpenSSF Scorecard workflow.
- Generates a Syft SPDX JSON SBOM for release artifacts and attaches it to releases.
- Adds GitHub Artifact Attestations for release ZIPs and the release SBOM.
- Leaves branch protection unchanged; that remains a separate policy decision.

Validation:
- PR #81, PR #82, and PR #83 checks passed before merging into optimization.
- Local release workflow YAML parse and whitespace checks passed during the feature PRs.
- This promotion PR should still run its own CI before merge.