### PR TITLE
ci(security): tighten workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -12,6 +12,9 @@ concurrency:
   group: sanitizers-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sanitize:
     name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.sanitizer }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,6 +33,9 @@ on:
       - 'model.weights'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-wasm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Summary:
- Adds explicit top-level read-only contents permissions to CI, sanitizer, and WASM workflows.
- Addresses the non-policy Scorecard token-permissions gap for workflows that had no top-level permissions.

Validation:
- Parsed changed workflow YAML files with Ruby.
- Ran git diff --check.
- Commit attribution audit found no AI/co-author trailers.

Deployment planning note:
- Updated project memory so launch/deployment work is zero-cost only: Vercel Hobby/free frontend, WASM-first inference, and optional free-tier backend candidates only after current limit verification.