### PR TITLE
ci(security): tighten workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -12,6 +12,9 @@ concurrency:
   group: sanitizers-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sanitize:
     name: ${{ matrix.os }} / ${{ matrix.compiler }} / ${{ matrix.sanitizer }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -33,6 +33,9 @@ on:
       - 'model.weights'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-wasm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit read-only contents permissions to CI, sanitizer, and WASM workflows
- Keep the Scorecard token-permissions cleanup observational and non-policy

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f} OK" }' .github/workflows/ci.yml .github/workflows/sanitizers.yml .github/workflows/wasm.yml
- git diff --check
- PR #85 checks passed before merge into optimization