### PR TITLE
ci(security): pin workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install OpenMP (macOS)
         if: runner.os == 'macOS'
@@ -42,10 +42,10 @@ jobs:
         working-directory: web
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
         language: [cpp, javascript-typescript]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild (C/C++)
         if: matrix.language == 'cpp'
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Lint commits with commitlint
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed
         with:
           configFile: web/commitlint.config.mjs

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install OpenMP (macOS)
         if: runner.os == 'macOS'
@@ -46,7 +46,7 @@ jobs:
           build/Release/fast_mnist_cli.exe README.md LICENSE
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fast_mnist_cli-${{ runner.os }}
           path: fast_mnist_cli-${{ runner.os }}.zip
@@ -62,12 +62,12 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: dist
 
       - name: Generate release SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
         with:
           path: dist
           format: spdx-json
@@ -77,18 +77,18 @@ jobs:
           upload-release-assets: false
 
       - name: Attest release artifacts
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-path: dist/**/*.zip
 
       - name: Attest release SBOM
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-path: dist/**/*.zip
           sbom-path: dist/fast_mnist_cli-release-sbom.spdx.json
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           name: Initial release
           generate_release_notes: true

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install OpenMP (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,14 +36,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           # Scorecard reads git metadata via the GitHub API with its own
           # token; leave the checkout token out of the workspace.
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
         with:
           results_file: results.sarif
           results_format: sarif
@@ -52,13 +52,13 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 14
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a
         with:
           sarif_file: results.sarif

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
+        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021
         with:
           version: 3.1.64
           actions-cache-folder: 'emsdk-cache'
@@ -79,7 +79,7 @@ jobs:
           ls -la dist-wasm/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fast_mnist_wasm
           path: dist-wasm/*

--- a/tools/bootstrap_macos.sh
+++ b/tools/bootstrap_macos.sh
@@ -8,6 +8,8 @@ fi
 
 brew install cmake libomp
 
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
 if python3 - <<'PY' >/dev/null 2>&1; then
 import tqdm  # noqa: F401
 PY
@@ -15,6 +17,7 @@ PY
 fi
 
 python3 -m pip install --user --break-system-packages \
-  --no-warn-script-location tqdm || {
+  --no-warn-script-location --require-hashes \
+  -r "$script_dir/requirements-bootstrap.txt" || {
   echo "tqdm install failed; prepare_mnist.py will use basic progress."
 }

--- a/tools/prepare_mnist.py
+++ b/tools/prepare_mnist.py
@@ -47,6 +47,7 @@ def enable_tqdm(auto_install: bool) -> bool:
     if not auto_install:
         return False
     print("tqdm not found; installing with pip...")
+    requirements = Path(__file__).with_name("requirements-bootstrap.txt")
     result = subprocess.run(
         [
             sys.executable,
@@ -56,7 +57,9 @@ def enable_tqdm(auto_install: bool) -> bool:
             "--user",
             "--break-system-packages",
             "--no-warn-script-location",
-            "tqdm",
+            "--require-hashes",
+            "-r",
+            str(requirements),
         ],
         check=False,
     )

--- a/tools/requirements-bootstrap.txt
+++ b/tools/requirements-bootstrap.txt
@@ -1,0 +1,2 @@
+tqdm==4.67.1 \
+    --hash=sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2


### PR DESCRIPTION
## Summary
- Pin GitHub Actions workflow dependencies to immutable commit SHAs
- Pin bootstrap tqdm installation through a hashed requirements file
- Continue the non-policy OpenSSF Scorecard cleanup track

## Validation
- PR #87 checks passed before merge into optimization
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f} OK" }' .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/commitlint.yml .github/workflows/gitleaks.yml .github/workflows/release.yml .github/workflows/sanitizers.yml .github/workflows/scorecard.yml .github/workflows/wasm.yml
- bash -n tools/bootstrap_macos.sh
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile tools/prepare_mnist.py
- python3 tools/prepare_mnist.py --help
- python3 -m pip install --dry-run --force-reinstall --user --break-system-packages --no-warn-script-location --require-hashes -r tools/requirements-bootstrap.txt
- git diff --check