### PR TITLE
Add matrix fuzzing harness

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder:v1
+
+COPY . $SRC/fast-mnist-nn
+WORKDIR $SRC/fast-mnist-nn
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+cd "$SRC/fast-mnist-nn"
+
+"$CXX" $CXXFLAGS -std=c++17 -Iinclude \
+  src/Matrix.cpp fuzz/matrix_stream_fuzzer.cpp \
+  "$LIB_FUZZING_ENGINE" -o "$OUT/matrix_stream_fuzzer"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,37 @@
+name: Fuzzing
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzzing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clusterfuzzlite:
+    name: ClusterFuzzLite / address
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        with:
+          language: c++
+          sanitizer: address
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1
+        with:
+          mode: code-change
+          sanitizer: address
+          fuzz-seconds: 120
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          output-sarif: false

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ docs/doxygen/
 # Web frontend
 web/node_modules/
 web/dist/
+web/playwright-report/
+web/test-results/
+web/public/wasm/
 
 # Compiled binaries
 test_model

--- a/fuzz/matrix_stream_fuzzer.cpp
+++ b/fuzz/matrix_stream_fuzzer.cpp
@@ -1,0 +1,118 @@
+#include "fast_mnist/Matrix.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <ios>
+#include <sstream>
+
+namespace {
+
+class FuzzBytes {
+  public:
+    FuzzBytes(const std::uint8_t* data, std::size_t size)
+        : data_(data), size_(size) {}
+
+    std::uint8_t next() {
+        if (size_ == 0) {
+            return 0;
+        }
+        const std::uint8_t value = data_[offset_ % size_];
+        ++offset_;
+        return value;
+    }
+
+    double nextValue() {
+        std::uint64_t bits = 0;
+        for (int i = 0; i < 8; ++i) {
+            bits = (bits << 8) | next();
+        }
+
+        double value = 0.0;
+        static_assert(sizeof(value) == sizeof(bits),
+                      "double and uint64_t must have equal size");
+        std::memcpy(&value, &bits, sizeof(value));
+        if (!std::isfinite(value)) {
+            const int centered = static_cast<int>(bits % 2049) - 1024;
+            return static_cast<double>(centered) / 16.0;
+        }
+        return std::clamp(value, -1024.0, 1024.0);
+    }
+
+  private:
+    const std::uint8_t* data_;
+    std::size_t size_;
+    std::size_t offset_{0};
+};
+
+void consumeMatrix(const Matrix& matrix) {
+    double sum = 0.0;
+    for (std::size_t r = 0; r < matrix.height(); ++r) {
+        for (std::size_t c = 0; c < matrix.width(); ++c) {
+            sum += matrix[r][c] * static_cast<double>(1 + r + c);
+        }
+    }
+
+    volatile double sink = sum;
+    (void)sink;
+}
+
+std::string buildMatrixInput(FuzzBytes& bytes) {
+    constexpr std::size_t MaxDimension = 8;
+    const std::size_t rows = bytes.next() % (MaxDimension + 1);
+    const std::size_t cols = bytes.next() % (MaxDimension + 1);
+
+    std::ostringstream stream;
+    stream << rows << ' ' << cols << '\n';
+    stream << std::setprecision(17);
+
+    for (std::size_t r = 0; r < rows; ++r) {
+        for (std::size_t c = 0; c < cols; ++c) {
+            if ((bytes.next() & 0x3f) == 0) {
+                stream << "invalid ";
+            } else {
+                stream << bytes.nextValue() << ' ';
+            }
+        }
+        stream << '\n';
+    }
+
+    return stream.str();
+}
+
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+                                      std::size_t size) {
+    if (size == 0) {
+        return 0;
+    }
+
+    FuzzBytes bytes(data, size);
+    Matrix matrix;
+    std::istringstream input(buildMatrixInput(bytes));
+    input >> matrix;
+
+    Matrix roundTrip = matrix.transpose().transpose();
+    Matrix scaled = roundTrip * 0.25;
+    Matrix combined = scaled + matrix;
+    combined.axpy(-0.25, matrix);
+
+    if (matrix.width() > 0) {
+        Matrix weights(matrix.width(), 1, 1.0);
+        consumeMatrix(matrix.dot(weights));
+    }
+
+    std::ostringstream output;
+    output << combined;
+    Matrix reparsed;
+    std::istringstream reparsedInput(output.str());
+    reparsedInput >> reparsed;
+
+    consumeMatrix(combined);
+    consumeMatrix(reparsed);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a ClusterFuzzLite PR workflow for the Matrix stream/parser surface
- add a bounded libFuzzer harness for matrix parse, transpose, scalar, add, axpy, dot, and stream round-trip paths
- ignore generated Playwright and reproducible WASM output directories

## Validation
- clang++ -std=c++17 -Iinclude -fsanitize=fuzzer-no-link,address -c fuzz/matrix_stream_fuzzer.cpp -o /tmp/fast_mnist_matrix_stream_fuzzer.o

Note: local Xcode clang does not include the libFuzzer runtime archive, so CI is the authoritative full ClusterFuzzLite run.