### PR TITLE
Prepare v1 finalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,20 +36,28 @@ jobs:
       - name: Package (macOS/Linux)
         if: runner.os != 'Windows'
         run: >
-          cmake -E tar cfv fast_mnist_cli-${{ runner.os }}.zip --format=zip
-          build/fast_mnist_cli README.md LICENSE
+          cmake -E tar cfv fast_mnist_native-${{ runner.os }}.zip --format=zip
+          build/fast_mnist_cli
+          build/fast_mnist_server
+          build/fast_mnist_trainer
+          build/export_weights
+          README.md LICENSE
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         run: >
-          cmake -E tar cfv fast_mnist_cli-${{ runner.os }}.zip --format=zip
-          build/Release/fast_mnist_cli.exe README.md LICENSE
+          cmake -E tar cfv fast_mnist_native-${{ runner.os }}.zip --format=zip
+          build/Release/fast_mnist_cli.exe
+          build/Release/fast_mnist_server.exe
+          build/Release/fast_mnist_trainer.exe
+          build/Release/export_weights.exe
+          README.md LICENSE
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: fast_mnist_cli-${{ runner.os }}
-          path: fast_mnist_cli-${{ runner.os }}.zip
+          name: fast_mnist_native-${{ runner.os }}
+          path: fast_mnist_native-${{ runner.os }}.zip
 
   publish-release:
     runs-on: ubuntu-latest
@@ -71,8 +79,8 @@ jobs:
         with:
           path: dist
           format: spdx-json
-          output-file: dist/fast_mnist_cli-release-sbom.spdx.json
-          artifact-name: fast_mnist_cli-release-sbom.spdx.json
+          output-file: dist/fast_mnist_native-release-sbom.spdx.json
+          artifact-name: fast_mnist_native-release-sbom.spdx.json
           upload-artifact: true
           upload-release-assets: false
 
@@ -85,13 +93,13 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-path: dist/**/*.zip
-          sbom-path: dist/fast_mnist_cli-release-sbom.spdx.json
+          sbom-path: dist/fast_mnist_native-release-sbom.spdx.json
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
-          name: Initial release
+          name: Fast MNIST NN ${{ github.ref_name }}
           generate_release_notes: true
           files: |
             dist/**/*.zip
-            dist/fast_mnist_cli-release-sbom.spdx.json
+            dist/fast_mnist_native-release-sbom.spdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-27
+
 ### Added
 - **Phase 0 — repo hygiene.** Track-branch workflow on GitHub with `hygiene`, `frontend`, `backend`, `optimization` long-running branches; feature PRs target tracks, major merges target `main`.
 - **Phase 0 — community health.** `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `.github/CODEOWNERS`, `.editorconfig`.
@@ -20,21 +22,22 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 - **Phase 2 — real activation viz.** Saliency + heatmap + softmax components wired to the new `/predict` payload.
 - **Phase 2 — paper-shaders hero backdrop.** Sticky-parallax pipeline for the landing surface.
 - **Docs.** README rewritten for current project state; `BENCHMARKS.md` extracted with methodology + analysis; `docs/adr/` seeded with ADR-0001 (hand-rolled SIMD), ADR-0002 (two-layer MLP), ADR-0003 (split server + SPA).
-
-### Changed
-- `web/src/api/predict.ts` API base is now env-driven (`VITE_API_BASE_URL`) with `http://localhost:8080` fallback for dev.
-- `web/src/App.tsx` wires the Phase 2 scaffolds (3D hero, canvas, activations) into the app shell.
-
-## [1.0.0] - 2026-04-22
-
-### Added
+- **Phase 6 — security release infrastructure.** OpenSSF Scorecard, pinned GitHub Actions dependencies, tightened workflow token permissions, release SBOM generation, GitHub artifact attestations, and a PR-only ClusterFuzzLite matrix harness.
+- **Phase 7 — animated demo polish.** Motion-driven command palette, first-viewport runnable classifier, scroll progress indicator, Framer-inspired 3D pipeline showcase, and Playwright desktop/mobile validation.
 - Interactive React frontend at `web/` — draw a digit on a 280×280 canvas, see live predictions with 300ms debounce.
 - Neural network visualisation with particle animation showing activations flowing through layers.
 - Dark/light theme toggle with system preference detection and localStorage persistence.
 - C++ HTTP API server (`apps/server.cpp`) exposing `/health` and `/predict` endpoints, 100-iteration timing comparison between baseline scalar and SIMD-optimized inference.
 
+### Changed
+- `web/src/api/predict.ts` API base is now env-driven (`VITE_API_BASE_URL`) with `http://localhost:8080` fallback for dev.
+- `web/src/App.tsx` wires the 3D hero, canvas, activations, command palette, JS fallback, and scroll-driven pipeline showcase into the app shell.
+- Release archives now package the native CLI, server, trainer, and weight exporter per OS, with SPDX SBOM and artifact attestations.
+- CMake project version bumped to `1.0.0`.
+
 ### Fixed
 - ESLint error: removed `setState` in `useEffect` cycle.
+- `web/package-lock.json` now includes all optional peer lock entries needed for clean `npm ci` on Node 20 CI.
 
 ### Infrastructure
 - README expanded with web frontend docs; VSCode IntelliSense C++ config updated.
@@ -55,5 +58,5 @@ The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.
 - Doxygen config + docs target.
 
 [Unreleased]: https://github.com/yadava5/fast-mnist-nn/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/yadava5/fast-mnist-nn/compare/v0.1.0...v1.0.0
+[1.0.0]: https://github.com/yadava5/fast-mnist-nn/releases/tag/v1.0.0
 [0.1.0]: https://github.com/yadava5/fast-mnist-nn/releases/tag/v0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(fast_mnist_nn VERSION 0.1.0 LANGUAGES CXX)
+project(fast_mnist_nn VERSION 1.0.0 LANGUAGES CXX)
 
 option(FAST_MNIST_ENABLE_OPENMP "Enable OpenMP support" ON)
 option(FAST_MNIST_ENABLE_NATIVE "Enable -march=native" OFF)

--- a/README.md
+++ b/README.md
@@ -14,18 +14,19 @@ run in your browser.
 [![ci][ci-badge]][ci-url]
 [![license][license-badge]][license-url]
 [![release][release-badge]][release-url]
-[![try it live][live-badge]][live-url]
+[![web app][web-badge]][web-url]
 [![openssf scorecard][scorecard-badge]][scorecard-url]
 
-## Try it live
+## Web demo
 
-[**fast-mnist-nn-yadava5.vercel.app**][live-url] — draw a digit, see the
-prediction, rotate the network.
+The React demo is ready for local use and zero-cost Vercel deployment. Draw a
+digit, see the prediction, rotate the network, and inspect the activation
+pipeline. See [`web/README.md`](web/README.md) for the deploy/run commands.
 
-> Hosted demo is a zero-cost Vercel deployment. It tries a C++ `/predict`
-> API first, then staged browser WASM artifacts, then a browser-only demo
-> classifier so the public app remains interactive without paid backend
-> hosting.
+> The public deployment target is Vercel Hobby with root directory `web`. It
+> tries a C++ `/predict` API first, then staged browser WASM artifacts, then a
+> browser-only demo classifier so the app remains interactive without paid
+> backend hosting.
 
 ## Demo preview
 
@@ -213,7 +214,7 @@ MIT — see [`LICENSE`](LICENSE).
 [license-url]: LICENSE
 [release-badge]: https://img.shields.io/github/v/release/yadava5/fast-mnist-nn?sort=semver
 [release-url]: https://github.com/yadava5/fast-mnist-nn/releases
-[live-badge]: https://img.shields.io/badge/try%20it-live-brightgreen
-[live-url]: https://fast-mnist-nn-yadava5.vercel.app
+[web-badge]: https://img.shields.io/badge/web-demo-brightgreen
+[web-url]: web/README.md
 [scorecard-badge]: https://api.securityscorecards.dev/projects/github.com/yadava5/fast-mnist-nn/badge
 [scorecard-url]: https://securityscorecards.dev/viewer/?uri=github.com/yadava5/fast-mnist-nn

--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ run in your browser.
 [**fast-mnist-nn-yadava5.vercel.app**][live-url] — draw a digit, see the
 prediction, rotate the network.
 
-> Hosted demo is a Vercel preview; the `/predict` endpoint falls back to an
-> in-browser WASM build if the C++ server is cold. If WASM artifacts are not
-> staged yet, the UI still runs with a browser-only demo classifier.
+> Hosted demo is a zero-cost Vercel deployment. It tries a C++ `/predict`
+> API first, then staged browser WASM artifacts, then a browser-only demo
+> classifier so the public app remains interactive without paid backend
+> hosting.
 
-## 30-second demo
+## Demo preview
 
-<!-- demo video is recorded via charm VHS once the hosted demo stabilises -->
-<video src="docs/branding/demo.mp4" width="760" autoplay muted loop playsinline>
-  Hand-drawn "7" classified in real time, with activations flowing through
-  the 784 → 100 → 10 network as the camera revolves around the 3D model.
-</video>
+<img src="web/public/hero-poster.svg" width="760"
+     alt="Fast MNIST NN animated web demo preview">
+
+Draw a digit, load the sample through the command palette, inspect real
+softmax and saliency output, and scroll through the animated 784 -> 100 -> 10
+pipeline stage.
 
 ## What it is
 

--- a/web/README.md
+++ b/web/README.md
@@ -21,6 +21,18 @@ The app tries prediction in this order:
 Use `Cmd+K` / `Ctrl+K` to open the animated command palette, load the sample
 digit, jump between sections, toggle theme, or reset the canvas.
 
+## Deploy
+
+Use Vercel Hobby/free with this directory as the project root:
+
+```sh
+vercel deploy --prod --yes
+```
+
+Build command: `npm run build`. Output directory: `dist`. Leave
+`VITE_API_BASE_URL` unset for a static, zero-cost deployment that relies on
+WASM or the browser-only fallback.
+
 ## Checks
 
 ```sh

--- a/web/README.md
+++ b/web/README.md
@@ -24,6 +24,9 @@ digit, jump between sections, toggle theme, or reset the canvas.
 ## Checks
 
 ```sh
+npm ci --no-audit --no-fund
 npm run lint
 npm run build
+npm run format:check
+npm run test:e2e
 ```


### PR DESCRIPTION
## Summary
- bump the CMake project version to 1.0.0
- reconcile the README, web README, changelog, and missing demo media reference for the v1 release
- package all native release tools and rename release artifacts/SBOM consistently

## Validation
- git diff --check
- npm ci --no-audit --no-fund --dry-run
- npm run format:check
- npm run lint
- npm run build
- npm run test:e2e (7 passed, 1 skipped)
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
- cmake --build build
- ctest --test-dir build --output-on-failure (34 passed)

Note: local Emscripten tools are not installed, so WASM validation remains covered by the existing GitHub WASM workflow.