### PR TITLE
fix(web): restore lucide 1.x build

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { Command } from 'cmdk';
 import {
   Brush,
   CornerDownLeft,
-  Github,
+  GitPullRequest,
   MoonStar,
   RotateCcw,
   Search,
@@ -131,7 +131,7 @@ export function CommandPalette({
       id: 'repo',
       label: 'Open repo on GitHub',
       detail: 'View source code',
-      icon: Github,
+      icon: GitPullRequest,
       keywords: ['github', 'repo', 'source'],
       run: () => {
         window.open('https://github.com/yadava5/fast-mnist-nn', '_blank', 'noopener');


### PR DESCRIPTION
## Summary
- replace the removed lucide-react Github icon with the supported GitPullRequest icon
- restore the frontend build after the lucide-react 1.x Dependabot update

## Validation
- npm run format:check
- npm run lint
- npm run build
- npm run test:e2e